### PR TITLE
Phold component compute

### DIFF
--- a/phold/Node.cpp
+++ b/phold/Node.cpp
@@ -53,7 +53,7 @@ Node::Node(SST::ComponentId_t id, SST::Params& params)
         additionalData = (char*)malloc(componentSize * sizeof(char));
     }
 
-    componentComputeCount = params.find<int>("componentCompute", 0);
+    componentComputeCount = params.find<int>("componentComputation", 0);
 
     recvCount = 0;
     numLinks = (2 * numRings + 1) * (2 * numRings + 1);

--- a/phold/Node.cpp
+++ b/phold/Node.cpp
@@ -144,6 +144,7 @@ SST::Interfaces::StringEvent* Node::createEvent()
 }
 
 void Node::componentCompute() {
+    #pragma NO_UNROLL
     for (int i = 0; i < componentComputeCount; i++) {
         computeSink = rng->generateNextUInt32();
     }

--- a/phold/Node.cpp
+++ b/phold/Node.cpp
@@ -53,6 +53,8 @@ Node::Node(SST::ComponentId_t id, SST::Params& params)
         additionalData = (char*)malloc(componentSize * sizeof(char));
     }
 
+    componentComputeCount = params.find<int>("componentCompute", 0);
+
     recvCount = 0;
     numLinks = (2 * numRings + 1) * (2 * numRings + 1);
 
@@ -141,6 +143,12 @@ SST::Interfaces::StringEvent* Node::createEvent()
     return ev;
 }
 
+void Node::componentCompute() {
+    for (int i = 0; i < componentComputeCount; i++) {
+        computeSink = rng->generateNextUInt32();
+    }
+}
+
 void Node::handleEvent(SST::Event* ev)
 {
     SST::Interfaces::StringEvent* payloadEv =
@@ -154,6 +162,8 @@ void Node::handleEvent(SST::Event* ev)
               << " with timestamp " << ev->getDeliveryTime() << "\n";
 #endif
     recvCount += 1;
+
+    componentCompute();
 
     size_t nextRecipientLinkId = movementFunction();
     while (links.at(nextRecipientLinkId) == nullptr) {

--- a/phold/Node.cpp
+++ b/phold/Node.cpp
@@ -247,6 +247,7 @@ void Node::serialize_order(SST::Core::Serialization::serializer& ser)
     SST_SER(largeEventFraction);
     SST_SER(additionalData);
     SST_SER(recvCount);
+    SST_SER(componentComputeCount);
 
     // SST RNG has built-in serialization support
     SST_SER(rng);

--- a/phold/Node.h
+++ b/phold/Node.h
@@ -20,6 +20,7 @@ public:
 
     bool tick(SST::Cycle_t currentCycle);
 
+    void componentCompute();
     void handleEvent(SST::Event* ev);
 
     SST::Interfaces::StringEvent* createEvent();
@@ -71,6 +72,9 @@ public:
          "0"},
         {"componentSize",
          "Additional size of components in bytes",
+         "0"},
+        {"componentCompute",
+         "How much additional computation to do as part of event handling, as a count of random numbers to generate and assign",
          "0"})
 
     SST_ELI_DOCUMENT_PORTS({{"port%d", "Ports to others", {}}})
@@ -101,6 +105,9 @@ public:
     int smallPayload, largePayload;
     float largeEventFraction;
     char* additionalData;
+    int componentComputeCount;
+    volatile int computeSink;
+    
 
     int recvCount;
 

--- a/phold/Node.h
+++ b/phold/Node.h
@@ -10,6 +10,14 @@
 #include <sst/dbg/SSTDebug.h>
 #endif
 
+#if defined(__clang__)
+    #define NO_UNROLL _Pragma("clang loop unroll(disable)")
+#elif defined(__GNUC__) && (__GNUC__ >= 8)
+    #define NO_UNROLL _Pragma("GCC unroll 1")
+#else
+    #define NO_UNROLL
+#endif
+
 class Node : public SST::Component {
 public:
     Node(SST::ComponentId_t id, SST::Params& params);

--- a/phold/Node.h
+++ b/phold/Node.h
@@ -10,6 +10,8 @@
 #include <sst/dbg/SSTDebug.h>
 #endif
 
+// Used to disable compiler optimizations on artificial work 
+// loops used to simulation component computation.
 #if defined(__clang__)
     #define NO_UNROLL _Pragma("clang loop unroll(disable)")
 #elif defined(__GNUC__) && (__GNUC__ >= 8)

--- a/phold/Node.h
+++ b/phold/Node.h
@@ -73,7 +73,7 @@ public:
         {"componentSize",
          "Additional size of components in bytes",
          "0"},
-        {"componentCompute",
+        {"componentComputation",
          "How much additional computation to do as part of event handling, as a count of random numbers to generate and assign",
          "0"})
 

--- a/phold/README.md
+++ b/phold/README.md
@@ -74,7 +74,7 @@ The PHOLD simulation has a large number of parameters:
 * `--exponent-multiplier`: For `phold.ExponentialNode`, this argument scales the exponential distribution from which additional delays on links are drawn.
 * `--small-payload`, `--large-payload`, and `large-event-fraction`: Each event carries an (unused) payload of either a small or large size. These parameters set those sizes, in bytes, and the fraction of events that are sent with the large payload. By default, small is 8 bytes, large is 1024 bytes, and large event fraction is 0.1.
 * `--component-size`: Each component has an additional field that is an allocated block of memory. This allows experimentation with the amount of memory used by each component. This argument controls the size of that field in bytes, and is 0 by default.
-* `--component-compute`: The number of random numbers a component should generate as part of handling an event. This allows simulations with more or less heavyweight components.
+* `--component-compute`: The number of random numbers a component should generate as part of handling an event. These numbers are ultimately thrown away and unused, but this is useful for modeling simulations with more or less computationally intensive event handling.
 * `--imbalance-factor`: This parameter adds thread-level load imbalance to the distribution of components. Values should be between 0 and 1. A value of 0 indicates perfect balance and a value of 1 indicates complete imbalance (all work on one thread). 
 * `--verbose`: This argument controls whether, at the end of the simulation, each component prints the number of events it received. This is useful for verifying correctness.
 
@@ -145,10 +145,12 @@ from workflow_processing import clean_and_calculate
 ```
 
 `generate_phold_args` takes arguments with the same names as the `submit.py` script above and, rather than launching the PHOLD simulations outright, generates tuples of arguments to use to invoke PHOLD simulations. 
-The output tuples are triples of the form `(srun_args, phold_args, run_name)`. 
-The `srun_args` are a tuple of the arguments that need to be passed to `srun` to request the correct resources for the job. 
+The output tuples are quadruples of the form `(srun_args, sst_args, phold_args, run_name)`. 
+The `srun_args` are a string of the arguments that need to be passed to `srun` to request the correct resources for the job. 
 This will include arguments like `--nodes=4` and `--ntasks-per-node=8`.
-The `phold_args` are a tuple of the arguments that are passed to the SST benchmark itself. 
+The `sst_args` are a string of the arguments passed to the `sst` command itself. 
+At this time, this is exclusively the thread count argument. 
+The `phold_args` are a string of the arguments that are passed to the SST benchmark itself. 
 This will include arguments like `--height 100` and `--componentSize 1024`.
 Finally, `run_name` is the a unique identifier for the run that can be used as the name for output directories and other files. 
 It concatenates the run's parameters into an identifier string.

--- a/phold/README.md
+++ b/phold/README.md
@@ -122,7 +122,7 @@ Each job that `submit.py` queues is actually an instance of the `dispatch.sh` co
 This command prepares the `sst` command, directing its outputs to different files, and collects global simulation metrics.
 The metrics collected are: build time, run stage time, maximum global memory usage, and maximum per-rank memory usage.
 
-## `consolidate.py`
+#### `consolidate.py`
 
 Once the runs from an experiment are done, the `consolidate.py` script can be used to gather the results into a single `.csv` file.
 The first argument to this script is the output `.csv` file name. All subsequent arguments are substrings to look for in the beginning of the output files.

--- a/phold/README.md
+++ b/phold/README.md
@@ -8,6 +8,7 @@ Some of the characteristic parameters in this implementation are:
 - distribution of the data sizes of components and events
 - number of events
 - link delays
+- computational intensity of event handling
 
 ## Prerequisites
 
@@ -73,6 +74,7 @@ The PHOLD simulation has a large number of parameters:
 * `--exponent-multiplier`: For `phold.ExponentialNode`, this argument scales the exponential distribution from which additional delays on links are drawn.
 * `--small-payload`, `--large-payload`, and `large-event-fraction`: Each event carries an (unused) payload of either a small or large size. These parameters set those sizes, in bytes, and the fraction of events that are sent with the large payload. By default, small is 8 bytes, large is 1024 bytes, and large event fraction is 0.1.
 * `--component-size`: Each component has an additional field that is an allocated block of memory. This allows experimentation with the amount of memory used by each component. This argument controls the size of that field in bytes, and is 0 by default.
+* `--component-compute`: The number of random numbers a component should generate as part of handling an event. This allows simulations with more or less heavyweight components.
 * `--imbalance-factor`: This parameter adds thread-level load imbalance to the distribution of components. Values should be between 0 and 1. A value of 0 indicates perfect balance and a value of 1 indicates complete imbalance (all work on one thread). 
 * `--verbose`: This argument controls whether, at the end of the simulation, each component prints the number of events it received. This is useful for verifying correctness.
 

--- a/phold/README.md
+++ b/phold/README.md
@@ -78,6 +78,8 @@ The PHOLD simulation has a large number of parameters:
 * `--imbalance-factor`: This parameter adds thread-level load imbalance to the distribution of components. Values should be between 0 and 1. A value of 0 indicates perfect balance and a value of 1 indicates complete imbalance (all work on one thread). 
 * `--verbose`: This argument controls whether, at the end of the simulation, each component prints the number of events it received. This is useful for verifying correctness.
 
+
+
 ## `submit.py` and `dispatch.sh`
 
 These two scripts, together, handle submitting, running, and collecting data from multiple PHOLD simulations in a single command.
@@ -131,6 +133,41 @@ This usually corresponds to the `--name` argument to the `submit.py` script. How
 Also keep in mind that in addition to the file containing the results of successful runs, `consolidate.py` also creates a parallel `.csv` file containing information about failures.
 This filename simply inserts `-failures` before the `.csv` in the provided output file argument.
 In the `exp-all` example, it would produce `exp-all-failures.csv`.
+
+## `workflow_*.py`
+
+There are also libraries in the repository for use in notebook-only workflows. 
+When writing notebook-based experiments/workflows using PHOLD, we recommend having the notebook clone a copy of this benchmark repository, then use the following import statements:
+```
+from submit import generate_phold_args
+from workflow_extractors import extract_results
+from workflow_processing import clean_and_calculate
+```
+
+`generate_phold_args` takes arguments with the same names as the `submit.py` script above and, rather than launching the PHOLD simulations outright, generates tuples of arguments to use to invoke PHOLD simulations. 
+The output tuples are triples of the form `(srun_args, phold_args, run_name)`. 
+The `srun_args` are a tuple of the arguments that need to be passed to `srun` to request the correct resources for the job. 
+This will include arguments like `--nodes=4` and `--ntasks-per-node=8`.
+The `phold_args` are a tuple of the arguments that are passed to the SST benchmark itself. 
+This will include arguments like `--height 100` and `--componentSize 1024`.
+Finally, `run_name` is the a unique identifier for the run that can be used as the name for output directories and other files. 
+It concatenates the run's parameters into an identifier string.
+
+
+`extract_results` helps process the output of PHOLD simulations. 
+It has two required arguments, `results_dir` and `sst_version`, and two optional arguments: `logfile_name` and `experiment_name`.
+`results_dir` should be the path to a directory containing subdirectories, each with a name matching a `run_name` from the `generate_phold_args` function.
+`extract_results` crawls through the subdirectories, extracting timing and resource usage information.
+It is important that the PHOLD simulation writes its output to a file within the subdirectory with a name matching `logfile_name`.
+The default value is `run.log`.
+`sst_version` should be a string representation of the version of SST in use. 
+This is important because timing information is reported differently for different versions of SST.
+Finally, `experiment_name`, if specified, is used as a filter for the results directory. 
+If used, only runs whose `name` arg matches the `experiment_name` will be collected.
+This function returns two dataframes, one of the successful runs and one of the failures.
+
+Finally, `clean_and_calculate` can be used to process the resulting DataFrames, filling out empty/unspecified columns and calculating useful performance metrics for evaluation.
+
 
 ## PHOLD AHP
 

--- a/phold/cleaning.py
+++ b/phold/cleaning.py
@@ -1,0 +1,323 @@
+
+import pandas as pd
+from plotnine import * 
+pd.set_option("display.max_columns", 100)
+
+def parameter_columns(): 
+  return ['Experiment Name', 'Node Count', 'Ranks Per Node', 'Thread Count',
+       'Width', 'Height', 'Event Density', 'Ring Size', 'Time to Run (ns)',
+       'Small Payload (bytes)', 'Large Payload (bytes)',
+       'Large Event Fraction', 'Imbalance Factor', 'Component Size']
+
+def varied_parameters(data):
+  mask = data[data.columns.intersection(parameter_columns())].nunique() > 1
+  return  mask.index[mask].tolist()
+
+def memory_columns():
+  return ['Max Local Memory Usage (GiB)',
+       'Max Global Memory Usage (GiB)', 'SLURM Allocated Memory (GiB)',
+       'Max Local Memory Utilization (%)', 'Max Global Memory Utilization (%)']
+
+  
+def measurement_columns():
+  return ['Build Time (s)', 'Run Time (s)', 'Max Resident Set Size (bytes)',
+       'Max Global Set Size (bytes)', 'Rank Sync Time Max (s)',
+       'Rank Sync Time Min (s)', 'Rank Sync Time Mean (s)',
+       'Rank Sync Time Std (s)', 'Rank Sync Count Max', 'Rank Sync Count Min',
+       'Rank Sync Count Mean', 'Rank Sync Count Std',
+       'Thread Sync Time Max (s)', 'Thread Sync Time Min (s)',
+       'Thread Sync Time Mean (s)', 'Thread Sync Time Std (s)',
+       'Thread Sync Count Max', 'Thread Sync Count Min',
+       'Thread Sync Count Mean', 'Thread Sync Count Std',
+       'Status']
+
+def calculated_columns():
+  return ['Rank Count', 'Total Threads', 'Threads Per Node', 'Components', 'Million Components',
+       'Components Per Node', 'Million Components Per Node', 'StencilLength',
+       'Total Links', 'Boundary Count', 'Remote Links', 'Remote Links (Ranks)',
+       'Remote Link Fraction (%)', 'Remote Link Fraction (%) (Ranks)',
+       'Links Per Component', 'Rows Per Node', 'Rows Per Rank',
+       'Million Links', 'Links Per Node', 'Million Links Per Node',
+       'Average Event Size (bytes)', 'Average Event Size (KiB)',
+       'Sync Time Mean (s)', 'Sync Time Max (s)', 'Sync Time Min (s)',
+       'Mean Sync Time Fraction (%)', 'Max Sync Time Fraction (%)',
+       'Min Sync Time Fraction (%)', 'Event Time Mean (s)', 'Event Count',
+       'Events/Second', 'Million Events Per Second',
+       'Synchronizations Per Second', 'Max Local Memory Usage (GiB)',
+       'Max Global Memory Usage (GiB)', 'SLURM Allocated Memory (GiB)',
+       'Max Local Memory Utilization (%)', 'Max Global Memory Utilization (%)',
+       'Nodes', 'Density', 'Remote Event Fraction (%)']
+
+def read_all_csvs(directory):
+  '''
+  Reads all CSV files in the given directory and concatenates them into a single DataFrame.
+  '''
+  import os
+  dataframes = []
+  for filename in os.listdir(directory):
+    if filename.endswith('.csv'):
+      filepath = os.path.join(directory, filename)
+      df = pd.read_csv(filepath)
+      df['File'] = filename  # Add a column with the filename
+      dataframes.append(df)
+  
+  return pd.concat(dataframes, ignore_index=True)
+
+def triangular(n):
+  return n * (n + 1) // 2
+
+   
+def total_link_count(ring_size, height, width):
+  stencil_length = 2 * ring_size + 1
+  total_links = (height * width) * (stencil_length **2)
+  total_links -= (height + width) * stencil_length * ring_size * (ring_size + 1)
+  total_links += (ring_size * (ring_size + 1)) ** 2
+  return total_links
+
+def total_remote_links(ring_size, width, boundary_count):
+  '''
+  Calculates the total number of remote links in a grid with the given ring size, global width, and boundary count.
+  This function assumes that the ring_size is is greater than or equal to the width of each node's portion of the grid.
+  '''
+  stencil_length = 2 * ring_size + 1
+  remote_links = width * stencil_length * ring_size * (ring_size + 1)
+
+  #This needs to account for any ghost remote links off the edge of the grid.
+  remote_links -= (ring_size * (ring_size + 1)) ** 2
+  return remote_links * boundary_count
+
+def remote_link_fraction(ring_size, height, width, boundary_count):
+  total_links = total_link_count(ring_size, height, width)
+  remote_links = total_remote_links(ring_size, width, boundary_count)
+  return 100 * remote_links / total_links if total_links > 0 else 0
+
+def height_from_fraction(target_fraction, ring_size, width, boundary_count):
+  '''
+  Calculates the height of the grid needed to get a given remote link target_.
+  Fraction should be a percentage (0-100).
+  '''
+  if target_fraction < 0 or target_fraction > 100:
+    raise ValueError("Target Fraction must be between 0 and 100.")
+  
+  remote_links = total_remote_links(ring_size, width, boundary_count)
+  
+  total_links = remote_links / (target_fraction / 100)
+  # Now we work backwards to the part of the expression containing the height
+  stencil_length = 2 * ring_size + 1
+  tmp = total_links - (ring_size * (ring_size + 1)) ** 2
+
+  tmp2 = tmp + width * stencil_length * ring_size * (ring_size + 1)
+
+  #tmp2 = height * width * stencilLength ** 2 - height * stencilLength * numRings * (numRings + 1)
+  #tmp2 = height * (width * stencilLength ** 2 - stencilLength * numRings * (numRings + 1)
+  height = tmp2 / (width * stencil_length ** 2 - stencil_length * ring_size * (ring_size + 1))
+  return height
+
+def fill_missing_fields(data):
+  if 'Small Payload (bytes)' not in data.columns:
+    data['Small Payload (bytes)'] = 0
+  if 'Large Payload (bytes)' not in data.columns:
+    data['Large Payload (bytes)'] = 0
+  if 'Large Event Fraction' not in data.columns:
+    data['Large Event Fraction'] = 0
+  return data
+
+
+def mem_based_fields(data):
+  data['Max Local Memory Usage (GiB)'] = data['Max Resident Set Size (bytes)'] / (1024.0 ** 3)
+  data['Max Global Memory Usage (GiB)'] = data['Max Global Set Size (bytes)'] / (1024.0 ** 3)
+  data['SLURM Allocated Memory (GiB)'] = 512.0 * data['Node Count'] # hotlum
+  data['Max Local Memory Utilization (%)'] = 100 * data['Max Local Memory Usage (GiB)'] / 512.0
+  data['Max Global Memory Utilization (%)'] = 100 * data['Max Global Memory Usage (GiB)'] / data['SLURM Allocated Memory (GiB)']
+
+  return data
+def time_based_fields(data):
+  if 'Sync Time Mean (s)' not in data.columns:
+    data['Sync Time Mean (s)'] = data['Rank Sync Time Mean (s)'] + data['Thread Sync Time Mean (s)']
+  if 'Sync Time Max (s)' not in data.columns:
+    data['Sync Time Max (s)'] = data['Rank Sync Time Max (s)'] + data['Thread Sync Time Max (s)']
+  if 'Sync Time Min (s)' not in data.columns:
+    data['Sync Time Min (s)'] = data['Rank Sync Time Min (s)'] + data['Thread Sync Time Min (s)']
+  data['Mean Sync Time Fraction (%)'] = 100 * data['Sync Time Mean (s)'] / data['Run Time (s)']
+  data['Max Sync Time Fraction (%)'] = 100 * data['Sync Time Max (s)'] / data['Run Time (s)']
+  data['Min Sync Time Fraction (%)'] = 100 * data['Sync Time Min (s)'] / data['Run Time (s)']
+  
+  data['Event Time Mean (s)'] = data['Run Time (s)'] - data['Sync Time Mean (s)']
+
+  data['Event Count'] = data['Time to Run (ns)'] * data['Event Density'] * data['Components']
+  data['Events/Second'] = data['Event Count'] / data['Run Time (s)']
+  data['Million Events Per Second'] = data['Events/Second'] / 1e6
+  data['Synchronizations Per Second'] = data['Time to Run (ns)'] / data['Run Time (s)']
+  data['Events/Second Total'] = data['Event Count'] / (data['Run Time (s)'] + data['Build Time (s)'])
+  data['Million Events Per Second Total'] = data['Events/Second Total'] / 1e6
+
+
+  data['SyncFraction'] = '0% to 10%'
+  data.loc[data['Mean Sync Time Fraction (%)'] >= 10, 'SyncFraction'] = '10% to 20%'
+  data.loc[data['Mean Sync Time Fraction (%)'] >= 20, 'SyncFraction'] = '20% to 30%'
+  data.loc[data['Mean Sync Time Fraction (%)'] >= 30, 'SyncFraction'] = '30% to 40%'
+  data.loc[data['Mean Sync Time Fraction (%)'] >= 40, 'SyncFraction'] = '40% to 50%'
+  data.loc[data['Mean Sync Time Fraction (%)'] >= 50, 'SyncFraction'] = '>50%'
+  data.loc[data['Status'] == 'Failure', 'SyncFraction'] = 'Failure'
+  
+  return data
+
+
+def topology_fields(data):
+  if 'Ranks Per Node' in data.columns:
+    data['Rank Count'] = data['Node Count'] * data['Ranks Per Node']
+  if 'Thread Count' in data.columns:
+    data['Total Threads'] = data['Rank Count'] * data['Thread Count']
+    data['Threads Per Node'] = data['Total Threads'] // data['Node Count']
+
+
+  data['Components'] = data['Width'] * data['Height']
+  data['Million Components'] = data['Components'] / 1e6
+  data['Components Per Node'] = data['Components'] / data['Node Count']
+  data['Million Components Per Node'] = data['Components Per Node'] / 1e6
+
+  # Total Links is counting unidirectional links
+  data['StencilLength'] = 2 * data['Ring Size'] + 1
+
+  # start as if each component had a full set of links
+  data['Total Links'] = data['Components'] * data['StencilLength'] ** 2
+
+  # Remove the links that aren't there around the edges
+  data['Total Links'] -= (data['Height'] + data['Width']) * data['StencilLength'] * data['Ring Size'] * (data['Ring Size'] + 1)
+
+  # Add back the corners of the edges that got counted twice
+  data['Total Links'] += (data['Ring Size'] * (data['Ring Size'] + 1)) ** 2
+
+
+  data['Total Links'] = total_link_count(data['Ring Size'], data['Height'], data['Width'])
+
+  # One less boundary than total nodes
+  data['Boundary Count'] = data['Node Count'] - 1
+
+  data['Remote Links'] = total_remote_links(data['Ring Size'], data['Width'], data['Boundary Count'])
+  data['Remote Links (Ranks)'] = total_remote_links(data['Ring Size'], data['Width'], data['Rank Count'] - 1)
+
+
+  data['Remote Link Fraction (%)'] = 100 * data['Remote Links'] / data['Total Links']
+  data['Remote Link Fraction (%) (Ranks)'] = 100 * data['Remote Links (Ranks)'] / data['Total Links']
+
+
+  data['Links Per Component'] = data['Total Links'] / data['Components']
+  data['Rows Per Node'] = data['Height'] / data['Node Count']
+  data['Rows Per Rank'] = data['Height'] / data['Rank Count']
+
+  data['Million Links'] = data['Total Links'] / 1e6
+  data['Links Per Node'] = data['Total Links'] / data['Node Count']
+  data['Million Links Per Node'] = data['Links Per Node'] / 1e6
+
+  data['Average Event Size (bytes)'] = data['Small Payload (bytes)'] * (1 - data['Large Event Fraction']) + data['Large Payload (bytes)'] * data['Large Event Fraction']
+
+  data['Average Event Size (KiB)'] = data['Average Event Size (bytes)'] / 1024.0
+
+  data = data[data['Rows Per Node'] >= data['Ring Size']].copy()
+
+  return data
+
+def add_aliases(data):
+
+  data['Nodes'] = data['Node Count']
+  data['Density'] = data['Event Density']
+  data['Remote Event Fraction (%)'] = data['Remote Link Fraction (%)']
+  return data
+
+def clean_and_calculate(data):
+  data = fill_missing_fields(data)
+  
+  data = topology_fields(data)
+  data = time_based_fields(data)
+  data = mem_based_fields(data)
+
+  data = add_aliases(data)
+
+  return data
+
+def clean_failures(data):
+  data = fill_missing_fields(data)
+  
+  data = topology_fields(data)
+
+  data = add_aliases(data)
+
+  return data
+
+def brandons_theme():
+  return theme(figure_size=(8,5),
+            axis_title_x=element_text(size=20),
+            axis_title_y=element_text(size=20),
+            axis_text_x=element_text(size=16),
+            axis_text_y=element_text(size=16),
+            legend_title=element_text(size=20),
+            legend_text=element_text(size=16),
+            legend_position='bottom',
+            legend_box='horizontal', 
+            legend_text_position='left',
+            legend_key_spacing_x=10 ) 
+
+
+def read_both(success_path):
+  successes = clean_and_calculate(pd.read_csv(success_path))
+  failure_path = success_path.replace('.csv', '-failures.csv')
+  failures = clean_failures(pd.read_csv(failure_path))
+  successes['Status'] = 'Success'
+  return (successes, failures)
+
+def read_all_data(success_path):
+  (successes,failures) = read_both(success_path)
+  return pd.concat([successes, failures], ignore_index=True)
+
+def read_data(success_path):
+  successes = clean_and_calculate(pd.read_csv(success_path))
+  successes['Status'] = 'Success'
+  return successes
+
+
+def orange(): 
+  return '#b35806'
+
+def purple():
+  return '#542788'
+
+def blue():
+  return '#0072B2'
+
+def red():
+   return '#DC3220'
+
+
+def color_to_color(c1, c2, num_points):
+  start_rgb = np.array(to_rgb(c1))
+  end_rgb = np.array(to_rgb(c2))
+  interpolated_colors = [
+    to_hex(start_rgb + (end_rgb - start_rgb) * i / (num_points - 1))
+    for i in range(num_points)
+  ]
+  return interpolated_colors
+
+def blue_to_red(num_points):
+  return color_to_color(blue(), red(), num_points)
+def blue_to_orange(num_points):
+  return color_to_color(blue(), orange(), num_points)
+  
+def orange_purple_diverging(num_points):
+  match num_points:
+    case 2:
+      return ['#f1a340', '#998ec3']
+    case 3:
+      return ['#f1a340','#f7f7f7','#998ec3']
+    case 4:
+      return ['#e66101', '#fdb863', '#b2abd2', '#5e3c99']
+    case 5:
+      return ['#e66101', '#fdb863', '#f7f7f7', '#b2abd2', '#5e3c99']
+    case 6:
+      return ['#b35806', '#f1a340','#fee0b6','#d8daeb','#998ec3','#542788']
+    case 7:
+      return ['#b35806','#f1a340','#fee0b6','#f7f7f7','#d8daeb','#998ec3','#542788']
+    case 8:
+      return ['#b35806','#e08214','#fdb863','#fee0b6','#d8daeb','#b2abd2','#8073ac','#542788']
+    case 'continuous':
+      raise ValueError(f"Unsupported number of colors: {num_points}")

--- a/phold/dispatch.sh
+++ b/phold/dispatch.sh
@@ -27,7 +27,7 @@ outDir=${prefix}_dir
 
 simFlags="--height $height --width $width --eventDensity $eventDensity --timeToRun ${timeToRun}ns --numRings $ringSize --smallPayload $smallPayload --largePayload $largePayload --largeEventFraction $largeEventFraction --imbalance-factor $imbalanceFactor --componentSize $componentSize --componentComputation $componentComputation"
 
-sstFlags="--num-threads $threadCount --print-timing-info=3 --parallel-load=SINGLE ${scriptDir}/phold_dist.py"
+sstFlags="--num-threads $threadCount --print-timing-info --parallel-load=SINGLE ${scriptDir}/phold_dist.py"
 
 srunPortion="srun --verbose --oom-kill-step=1 -N $nodeCount --cpus-per-task=$threadCount --ntasks-per-node=$ranksPerNode"
 

--- a/phold/dispatch.sh
+++ b/phold/dispatch.sh
@@ -16,7 +16,8 @@ largePayload=${10}
 largeEventFraction=${11}
 imbalanceFactor=${12}
 componentSize=${13}
-prefix=${14}
+componentComputation=${14}
+prefix=${15}
 
 tmpFile=${prefix}.tmp
 timeFile=${prefix}.time
@@ -24,7 +25,7 @@ outFile=${prefix}.err
 outDir=${prefix}_dir
 
 
-simFlags="--height $height --width $width --eventDensity $eventDensity --timeToRun ${timeToRun}ns --numRings $ringSize --smallPayload $smallPayload --largePayload $largePayload --largeEventFraction $largeEventFraction --imbalance-factor $imbalanceFactor --componentSize $componentSize"
+simFlags="--height $height --width $width --eventDensity $eventDensity --timeToRun ${timeToRun}ns --numRings $ringSize --smallPayload $smallPayload --largePayload $largePayload --largeEventFraction $largeEventFraction --imbalance-factor $imbalanceFactor --componentSize $componentSize --componentComputation $componentComputation"
 
 sstFlags="--num-threads $threadCount --print-timing-info=3 --parallel-load=SINGLE ${scriptDir}/phold_dist.py"
 

--- a/phold/extractors.py
+++ b/phold/extractors.py
@@ -197,6 +197,7 @@ def extract_parameters(results_dir):
   large_event_fraction = float(parts[11])
   imbalance_factor = float(parts[12]) if len(parts) > 12 else 0.0  # Default to 0.0 if not present
   component_size = int(parts[13]) if len(parts) > 13 else 0.0
+  component_computation = int(parts[14]) if len(parts) > 14 else 0.0
 
   return {
     'Experiment Name': experiment_name,
@@ -212,7 +213,8 @@ def extract_parameters(results_dir):
     'Large Payload (bytes)': large_payload,
     'Large Event Fraction': large_event_fraction,
     'Imbalance Factor': imbalance_factor,
-    "Component Size": component_size
+    "Component Size": component_size,
+    "Component Computation": component_computation
   }
 
 

--- a/phold/phold_dist.py
+++ b/phold/phold_dist.py
@@ -109,7 +109,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help=(
-            "Amount of additional computation to do as part of event handling, "
+            "Amount of additional artificial computation to do as part of event handling, "
             "as a count of random numbers to generate and assign to a volatile variable."
         ),
     )

--- a/phold/phold_dist.py
+++ b/phold/phold_dist.py
@@ -105,6 +105,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Size of the additional data field of the component in bytes",
     )
     parser.add_argument(
+        "--componentCompute", '--component-compute',
+        type=int,
+        default=0,
+        help=(
+            "Amount of additional computation to do as part of event handling, "
+            "as a count of random numbers to generate and assign to a volatile variable."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         type=int,
         default=0,
@@ -174,6 +183,7 @@ def create_component(i: int, j: int, args, rows_per_rank: int, num_ranks: int,
             "largeEventFraction": args.largeEventFraction,
             "verbose": args.verbose,
             "componentSize": args.componentSize,
+            "componentCompute": args.componentCompute,
         }
     )
     comp.setRank(

--- a/phold/phold_dist.py
+++ b/phold/phold_dist.py
@@ -105,7 +105,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Size of the additional data field of the component in bytes",
     )
     parser.add_argument(
-        "--componentCompute", '--component-compute',
+        "--componentComputation", '--component-computation',
         type=int,
         default=0,
         help=(
@@ -183,7 +183,7 @@ def create_component(i: int, j: int, args, rows_per_rank: int, num_ranks: int,
             "largeEventFraction": args.largeEventFraction,
             "verbose": args.verbose,
             "componentSize": args.componentSize,
-            "componentCompute": args.componentCompute,
+            "componentComputation": args.componentComputation,
         }
     )
     comp.setRank(

--- a/phold/submit.py
+++ b/phold/submit.py
@@ -8,19 +8,58 @@ import random
 working_dir = os.getcwd()
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
-def int_list(value):
+def int_list(value: str) -> list[int]:
+  """Parse a whitespace-separated string into a list of integers.
+  Args:
+      value: A whitespace-separated string of integers or mathematical expressions.
+      
+  Returns:
+      A list of integers parsed from the input string.
+      
+  Raises:
+      argparse.ArgumentTypeError: If the input cannot be converted to integers.
+      
+  Examples:
+      >>> int_list('1 2 3')
+      [1, 2, 3]
+      >>> int_list('1 2*2 4')
+      [1, 4, 4]
+  """
   try:
     return [int(eval(x)) for x in value.split()]
   except ValueError:
     raise argparse.ArgumentTypeError(f"Invalid list of integers: '{value}'")
   
-def float_list(value):
+def float_list(value: str) -> list[float]:
+  """Parse a whitespace-separated string into a list of floating-point numbers.
+
+  Args:
+      value: A whitespace-separated string of floating-point numbers.
+      
+  Returns:
+      A list of floats parsed from the input string.
+      
+  Raises:
+      argparse.ArgumentTypeError: If the input cannot be converted to floats.
+      
+  Examples:
+      >>> float_list('0.1 0.5 1.0')
+      [0.1, 0.5, 1.0]
+      >>> float_list('1.5 2.5 3.5')
+      [1.5, 2.5, 3.5]
+  """
   try:
     return [float(x) for x in value.split()]
   except ValueError:
     raise argparse.ArgumentTypeError(f"Invalid list of floats: '{value}'")
 
-def parse_arguments():
+def parse_arguments() -> argparse.Namespace:
+  """Parse and validate command-line arguments for PHOLD benchmark submission.
+  
+  Raises:
+      AssertionError: If neither --width nor --components-per-node is specified.
+      SystemExit: If parsing fails or required arguments are missing.
+  """
   parser = argparse.ArgumentParser(description="Submit PHOLD benchmark jobs.")
 
   parser.add_argument('--node_counts', '--node-counts', type=int_list, help="List of node counts to use for the benchmark, e.g., '4 8 16'", required=True)
@@ -59,6 +98,9 @@ def parse_arguments():
 
 
 def convert_to_ranges(args):
+  """
+  Normalizes the arguments for stochastic runs by expanding single-value arguments into a single-value range.
+  """
   if args.stochastic is not None:
     # Turn the single values into ranges with a single element
     if len(args.node_counts) == 1:
@@ -96,11 +138,11 @@ def convert_to_ranges(args):
 
 # 
 def stochastic_grid_shapes(args):
-  '''
+  """
   Calculate grid shapes for stochastic runs. 
   We are treating the arguments as ranges, and need to sample from them based 
   on if we are doing weak scaling and if the components_per_node or width is specified
-  '''
+  """
 
   node_counts = []
   for i in range(args.stochastic):
@@ -165,31 +207,28 @@ def calculate_grid_shapes(args):
       shapes.append((grid_width, grid_height, node_count, rank_count, thread_count))
   return shapes
 
-def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1], 
-                        widths=[100], heights=[100], components_per_node=None,
-                        event_densities=[0.1], ring_sizes=[1], times_to_run=[1000],
-                        small_payloads=[8], large_payloads=[1024], large_event_fractions=[0.0], 
-                        imbalance_factors=[0.0], component_sizes=[0], component_computations=[0],
-                        name="phold", weak_scaling=False, stochastic=None):
-  args = argparse.Namespace(node_counts=node_counts, thread_counts=thread_counts, rank_counts=rank_counts, widths=widths, heights=heights,
-                          components_per_node=components_per_node, event_densities=event_densities, ring_sizes=ring_sizes, times_to_run=times_to_run,
-                          small_payloads=small_payloads, large_payloads=large_payloads, large_event_fractions=large_event_fractions, 
-                          imbalance_factors=imbalance_factors, component_sizes=component_sizes, component_computations=component_computations,
-                          name=name, weak_scaling=weak_scaling, stochastic=stochastic)
-  
-  
+def generate_parameter_list(args):
+  """
+  Given an argparser Namespace `args`, produces a list of tuples representing the parameters of each run to execute. 
+  Each tuple contains two tuples: (shape_parameter_tuple, non_shape_parameter_tuple).
+  The shape parameter tuple is: (width, height, node_count, rank_count, thread_count)
+  The non-shape parameter tuple is:
+    (event_density, ring_size, time_to_run, 
+     small_payload, large_payload, large_event_fraction, 
+     imbalance_factor, component_size, component_computation)
+  """
   args = convert_to_ranges(args)
   if args.stochastic is not None:
-    
     shape_parameters = stochastic_grid_shapes(args)
-    
     non_shape_parameters = []
     for i in range(args.stochastic):
       density = round(random.uniform(*args.event_densities), 2)
-      non_shape_point = (density, random.randint(*args.ring_sizes), random.randint(*args.times_to_run), random.randint(*args.small_payloads),
-              random.randint(*args.large_payloads), random.uniform(*args.large_event_fractions), random.uniform(*args.imbalance_factors), random.randint(*args.component_sizes), random.randint(*args.component_computations))
+      non_shape_point = (density, random.randint(*args.ring_sizes), 
+                         random.randint(*args.times_to_run), random.randint(*args.small_payloads),
+                         random.randint(*args.large_payloads), random.uniform(*args.large_event_fractions),
+                         random.uniform(*args.imbalance_factors), random.randint(*args.component_sizes), 
+                         random.randint(*args.component_computations))
       non_shape_parameters.append(non_shape_point)
-
     parameters = list(zip(shape_parameters, non_shape_parameters))
   else:
     # Non stochastic run, so we do cartesian product of the parameters
@@ -198,11 +237,86 @@ def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1],
                                                   args.small_payloads, args.large_payloads, args.large_event_fractions, 
                                                   args.imbalance_factors, args.component_sizes, args.component_computations))
     parameters = list(itertools.product(shape_parameters, non_shape_parameters))
+  
+  return parameters
 
-  arg_tuples = []
+def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1], 
+                        widths=[100], heights=[100], components_per_node=None,
+                        event_densities=[0.1], ring_sizes=[1], times_to_run=[1000],
+                        small_payloads=[8], large_payloads=[1024], large_event_fractions=[0.0], 
+                        imbalance_factors=[0.0], component_sizes=[0], component_computations=[0],
+                        name="phold", weak_scaling=False, stochastic=None) -> list[tuple[str, str, str]]:
+  """Generate PHOLD benchmark parameter combinations and corresponding srun/phold arguments.
+  
+  This is the primary library interface for generating PHOLD benchmark configurations.
+  It supports both deterministic parametric sweeps (Cartesian product of parameters) and
+  stochastic sampling of the parameter space. Useful for notebook workflows and programmatic
+  benchmark configuration.
+  
+  Args:
+      node_counts (list[int]): Node counts for benchmark runs. Each value represents the number
+          of computing nodes to allocate for a run. Default is [1].
+      thread_counts (list[int]): Thread counts per node. Controls CPU parallelism within each rank.
+          Default is [1].
+      rank_counts (list[int]): Number of MPI ranks to run per node. Controls MPI parallelism
+          within each node. Default is [1].
+      widths (list[int]): Grid widths for the simulation. Represents the first dimension of the
+          component grid. Either this or components_per_node must be specified. Default is [100].
+      heights (list[int]): Grid heights or per-node heights (see weak_scaling). Represents the
+          second dimension over which the grid is distributed. Default is [100].
+      components_per_node (list[int] | None): Target component counts per node. When specified,
+          grid widths are dynamically calculated to achieve approximately this many components per
+          node. Mutually exclusive with direct width specification for weak scaling calculations.
+          Default is None.
+      event_densities (list[float]): Event densities for the simulation. Controls the frequency
+          of events generated per component. Higher densities produce more events. Examples: 0.1, 0.5, 10.
+          Default is [0.1].
+      ring_sizes (list[int]): Number of rings of neighboring components each component should connect to.
+          Controls graph connectivity. ring_size=1 means only immediate neighbors, ring_size=2 includes
+          neighbors one ring further out, etc. Default is [1].
+      times_to_run (list[int]): Simulation times in nanoseconds (ns). Controls how long each simulation runs.
+          Examples: 1000, 10000, 100000. Default is [1000].
+      small_payloads (list[int]): Small event payload sizes in bytes. Default is [8].
+      large_payloads (list[int]): Large event payload sizes in bytes. Default is [1024].
+      large_event_fractions (list[float]): Fraction of events that should be large (vs. small).
+          Must be in range [0.0, 1.0]. 0.0 means all events are small, 1.0 means all are large.
+          Default is [0.0].
+      imbalance_factors (list[float]): Load imbalance factors. Controls computational load variation
+          across components. 0.0 means perfectly balanced, > 0.0 introduces increasing imbalance.
+          Default is [0.0].
+      component_sizes (list[int]): Component memory sizes in bytes. Allows simulation of varying
+          component footprints. Default is [0] (minimal).
+      component_computations (list[int]): Computation iterations per event. Controls the amount of
+          work performed per event reception. Specified in random number generations. Default is [0] (no computation).
+      name (str): Job name prefix prepended to all output filenames. Useful for organizing benchmark runs.
+          Default is "phold".
+      weak_scaling (bool): If True, height parameters are treated as per-node heights (components scale
+          with node count). If False, height represents the total grid height (strong scaling).
+          Default is False.
+      stochastic (int | None): If set to a positive integer N, treats list parameters as range bounds
+          [min, max] and randomly samples N points from each parameter's range instead of performing
+          a Cartesian product. Enables efficient exploration of high-dimensional parameter spaces.
+          Default is None (deterministic Cartesian product).
+          
+  Returns:
+      list[tuple[str, str, str]]: List of tuples, one per benchmark run, containing:
+          - srun_args (str): srun command-line arguments (--nodes, --cpus-per-task, --ntasks-per-node)
+          - phold_args (str): PHOLD executable arguments (height, width, event density, etc.)
+          - run_name (str): Unique identifier for the run based on all parameters
+  """
+
+  args = argparse.Namespace(node_counts=node_counts, thread_counts=thread_counts, rank_counts=rank_counts, widths=widths, heights=heights,
+                          components_per_node=components_per_node, event_densities=event_densities, ring_sizes=ring_sizes, times_to_run=times_to_run,
+                          small_payloads=small_payloads, large_payloads=large_payloads, large_event_fractions=large_event_fractions, 
+                          imbalance_factors=imbalance_factors, component_sizes=component_sizes, component_computations=component_computations,
+                          name=name, weak_scaling=weak_scaling, stochastic=stochastic)
+  
+  parameter_tuples = generate_parameter_list(args)
+  
+  arg_tuples = [] # The triples that contain the srun arguments, phold script arguments, and the run name
   for ((width, height, node_count, rank_count, thread_count), 
        (event_density, ring_size, time_to_run, small_payload, large_payload, 
-        large_event_fraction, imbalance_factor, component_size, component_computation)) in parameters:
+        large_event_fraction, imbalance_factor, component_size, component_computation)) in parameter_tuples:
     srun_args = f"--nodes={node_count} --cpus-per-task={thread_count} --ntasks-per-node={rank_count}"
     phold_args = f"--height {height} --width {width} --eventDensity {event_density} --timeToRun {time_to_run}ns --numRings {ring_size} --smallPayload {small_payload} --largePayload {large_payload} --largeEventFraction {large_event_fraction} --imbalance-factor {imbalance_factor} --componentSize {component_size} --componentComputation {component_computation}"
     run_name = f"{name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}_{component_computation}"
@@ -216,27 +330,7 @@ if __name__ == "__main__":
   subprocess.run("make", shell=True, check=True)
   os.chdir(working_dir)
 
-  args = convert_to_ranges(args)
-  if args.stochastic is not None:
-    
-    shape_parameters = stochastic_grid_shapes(args)
-    
-    non_shape_parameters = []
-    for i in range(args.stochastic):
-      density = round(random.uniform(*args.event_densities), 2)
-      non_shape_point = (density, random.randint(*args.ring_sizes), random.randint(*args.times_to_run), random.randint(*args.small_payloads),
-              random.randint(*args.large_payloads), random.uniform(*args.large_event_fractions), random.uniform(*args.imbalance_factors), random.randint(*args.component_sizes), random.randint(*args.component_computations))
-      non_shape_parameters.append(non_shape_point)
-
-    parameters = list(zip(shape_parameters, non_shape_parameters))
-  else:
-    # Non stochastic run, so we do cartesian product of the parameters
-
-    shape_parameters = calculate_grid_shapes(args)
-    non_shape_parameters = list(itertools.product(args.event_densities, args.ring_sizes, args.times_to_run,
-                                                  args.small_payloads, args.large_payloads, args.large_event_fractions, 
-                                                  args.imbalance_factors, args.component_sizes, args.component_computations))
-    parameters = list(itertools.product(shape_parameters, non_shape_parameters))
+  parameters = generate_parameter_list(args)
 
   print("parameters: ", parameters)
   for ((width, height, node_count, rank_count, thread_count), (event_density, ring_size, time_to_run, small_payload, large_payload, large_event_fraction, imbalance_factor, component_size, component_computation)) in parameters:

--- a/phold/submit.py
+++ b/phold/submit.py
@@ -39,6 +39,7 @@ def parse_arguments():
   parser.add_argument('--name', type=str, default="phold", help="(Optional) Name of the benchmark job prepended to output files.")
   parser.add_argument('--imbalance_factors', '--imbalance-factors', '--imbalance-factor', type=float_list, default=[0.0], help="List of imbalance fractions to use, e.g., '0.1 0.2 0.5'. Default is [0.0].")
   parser.add_argument('--component_sizes', '--component-sizes', '--component-size', type=int_list, default=[0], help="List of component sizes to use, in bytes. Default is [0]")
+  parser.add_argument('--component_computations', '--component-computations', '--component-computation', type=int_list, default=[0], help="List of component computation times to use, in random number generations per event. Default is [0]")
 
   # Weak scaling is used to indicate that the combinations of height and width are the "per-node" shape.
   # With a weak scaling run, if we vary the height, we are varying the per-node component count.
@@ -88,6 +89,8 @@ def convert_to_ranges(args):
       args.components_per_node = [args.components_per_node[0]] * 2
     if args.component_sizes is not None and len(args.component_sizes) == 1:
       args.component_sizes = [args.component_sizes[0]] * 2
+    if args.component_computations is not None and len(args.component_computations) == 1:
+      args.component_computations = [args.component_computations[0]] * 2
   return args
 
 
@@ -179,7 +182,7 @@ if __name__ == "__main__":
     for i in range(args.stochastic):
       density = round(random.uniform(*args.event_densities), 2)
       non_shape_point = (density, random.randint(*args.ring_sizes), random.randint(*args.times_to_run), random.randint(*args.small_payloads),
-              random.randint(*args.large_payloads), random.uniform(*args.large_event_fractions), random.uniform(*args.imbalance_factors), random.randint(*args.component_sizes))
+              random.randint(*args.large_payloads), random.uniform(*args.large_event_fractions), random.uniform(*args.imbalance_factors), random.randint(*args.component_sizes), random.randint(*args.component_computations))
       non_shape_parameters.append(non_shape_point)
 
     parameters = list(zip(shape_parameters, non_shape_parameters))
@@ -188,14 +191,15 @@ if __name__ == "__main__":
 
     shape_parameters = calculate_grid_shapes(args)
     non_shape_parameters = list(itertools.product(args.event_densities, args.ring_sizes, args.times_to_run,
-                                                  args.small_payloads, args.large_payloads, args.large_event_fractions, args.imbalance_factors, args.component_sizes))
+                                                  args.small_payloads, args.large_payloads, args.large_event_fractions, 
+                                                  args.imbalance_factors, args.component_sizes, args.component_computations))
     parameters = list(itertools.product(shape_parameters, non_shape_parameters))
 
   print("parameters: ", parameters)
-  for ((width, height, node_count, rank_count, thread_count), (event_density, ring_size, time_to_run, small_payload, large_payload, large_event_fraction, imbalance_factor, component_size)) in parameters:
-    output_file = f"{args.name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}"
+  for ((width, height, node_count, rank_count, thread_count), (event_density, ring_size, time_to_run, small_payload, large_payload, large_event_fraction, imbalance_factor, component_size, component_computation)) in parameters:
+    output_file = f"{args.name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}_{component_computation}"
     sbatch_portion = f"sbatch -N {node_count} -o {output_file}.out"
-    command = f"{sbatch_portion} {script_dir}/dispatch.sh {node_count} {rank_count} {thread_count} {width} {height} {event_density} {ring_size} {time_to_run} {small_payload} {large_payload} {large_event_fraction} {imbalance_factor} {component_size} {output_file}"
+    command = f"{sbatch_portion} {script_dir}/dispatch.sh {node_count} {rank_count} {thread_count} {width} {height} {event_density} {ring_size} {time_to_run} {small_payload} {large_payload} {large_event_fraction} {imbalance_factor} {component_size} {component_computation} {output_file}"
     print(command)
     if not args.dry_run:
       print(f"Running: {command}")

--- a/phold/submit.py
+++ b/phold/submit.py
@@ -299,8 +299,9 @@ def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1],
           Default is None (deterministic Cartesian product).
           
   Returns:
-      list[tuple[str, str, str]]: List of tuples, one per benchmark run, containing:
+      list[tuple[str, str, str, str]]: List of tuples, one per benchmark run, containing:
           - srun_args (str): srun command-line arguments (--nodes, --cpus-per-task, --ntasks-per-node)
+          - sst_args (str): sst command-line arguments (primarily thread count)
           - phold_args (str): PHOLD executable arguments (height, width, event density, etc.)
           - run_name (str): Unique identifier for the run based on all parameters
   """
@@ -313,14 +314,15 @@ def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1],
   
   parameter_tuples = generate_parameter_list(args)
   
-  arg_tuples = [] # The triples that contain the srun arguments, phold script arguments, and the run name
+  arg_tuples = [] # The quadruples that contain the srun arguments, sst arguments, phold script arguments, and the run name
   for ((width, height, node_count, rank_count, thread_count), 
        (event_density, ring_size, time_to_run, small_payload, large_payload, 
         large_event_fraction, imbalance_factor, component_size, component_computation)) in parameter_tuples:
     srun_args = f"--nodes={node_count} --cpus-per-task={thread_count} --ntasks-per-node={rank_count}"
+    sst_args = f"--threads={thread_count}"
     phold_args = f"--height {height} --width {width} --eventDensity {event_density} --timeToRun {time_to_run}ns --numRings {ring_size} --smallPayload {small_payload} --largePayload {large_payload} --largeEventFraction {large_event_fraction} --imbalance-factor {imbalance_factor} --componentSize {component_size} --componentComputation {component_computation}"
     run_name = f"{name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}_{component_computation}"
-    arg_tuples.append((srun_args, phold_args, run_name))
+    arg_tuples.append((srun_args, sst_args, phold_args, run_name))
   return arg_tuples
 
 if __name__ == "__main__":
@@ -333,7 +335,8 @@ if __name__ == "__main__":
   parameters = generate_parameter_list(args)
 
   print("parameters: ", parameters)
-  for ((width, height, node_count, rank_count, thread_count), (event_density, ring_size, time_to_run, small_payload, large_payload, large_event_fraction, imbalance_factor, component_size, component_computation)) in parameters:
+  for ((width, height, node_count, rank_count, thread_count), 
+       (event_density, ring_size, time_to_run, small_payload, large_payload, large_event_fraction, imbalance_factor, component_size, component_computation)) in parameters:
     output_file = f"{args.name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}_{component_computation}"
     sbatch_portion = f"sbatch -N {node_count} -o {output_file}.out"
     command = f"{sbatch_portion} {script_dir}/dispatch.sh {node_count} {rank_count} {thread_count} {width} {height} {event_density} {ring_size} {time_to_run} {small_payload} {large_payload} {large_event_fraction} {imbalance_factor} {component_size} {component_computation} {output_file}"

--- a/phold/submit.py
+++ b/phold/submit.py
@@ -165,6 +165,49 @@ def calculate_grid_shapes(args):
       shapes.append((grid_width, grid_height, node_count, rank_count, thread_count))
   return shapes
 
+def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1], 
+                        widths=[100], heights=[100], components_per_node=None,
+                        event_densities=[0.1], ring_sizes=[1], times_to_run=[1000],
+                        small_payloads=[8], large_payloads=[1024], large_event_fractions=[0.0], 
+                        imbalance_factors=[0.0], component_sizes=[0], component_computations=[0],
+                        name="phold", weak_scaling=False, stochastic=None):
+  args = argparse.Namespace(node_counts=node_counts, thread_counts=thread_counts, rank_counts=rank_counts, widths=widths, heights=heights,
+                          components_per_node=components_per_node, event_densities=event_densities, ring_sizes=ring_sizes, times_to_run=times_to_run,
+                          small_payloads=small_payloads, large_payloads=large_payloads, large_event_fractions=large_event_fractions, 
+                          imbalance_factors=imbalance_factors, component_sizes=component_sizes, component_computations=component_computations,
+                          name=name, weak_scaling=weak_scaling, stochastic=stochastic)
+  
+  
+  args = convert_to_ranges(args)
+  if args.stochastic is not None:
+    
+    shape_parameters = stochastic_grid_shapes(args)
+    
+    non_shape_parameters = []
+    for i in range(args.stochastic):
+      density = round(random.uniform(*args.event_densities), 2)
+      non_shape_point = (density, random.randint(*args.ring_sizes), random.randint(*args.times_to_run), random.randint(*args.small_payloads),
+              random.randint(*args.large_payloads), random.uniform(*args.large_event_fractions), random.uniform(*args.imbalance_factors), random.randint(*args.component_sizes), random.randint(*args.component_computations))
+      non_shape_parameters.append(non_shape_point)
+
+    parameters = list(zip(shape_parameters, non_shape_parameters))
+  else:
+    # Non stochastic run, so we do cartesian product of the parameters
+    shape_parameters = calculate_grid_shapes(args)
+    non_shape_parameters = list(itertools.product(args.event_densities, args.ring_sizes, args.times_to_run,
+                                                  args.small_payloads, args.large_payloads, args.large_event_fractions, 
+                                                  args.imbalance_factors, args.component_sizes, args.component_computations))
+    parameters = list(itertools.product(shape_parameters, non_shape_parameters))
+
+  arg_tuples = []
+  for ((width, height, node_count, rank_count, thread_count), 
+       (event_density, ring_size, time_to_run, small_payload, large_payload, 
+        large_event_fraction, imbalance_factor, component_size, component_computation)) in parameters:
+    srun_args = f"--nodes={node_count} --cpus-per-task={thread_count} --ntasks-per-node={rank_count}"
+    phold_args = f"--height {height} --width {width} --eventDensity {event_density} --timeToRun {time_to_run}ns --numRings {ring_size} --smallPayload {small_payload} --largePayload {large_payload} --largeEventFraction {large_event_fraction} --imbalance-factor {imbalance_factor} --componentSize {component_size} --componentComputation {component_computation}"
+    run_name = f"{name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}_{component_computation}"
+    arg_tuples.append((srun_args, phold_args, run_name))
+  return arg_tuples
 
 if __name__ == "__main__":
   args = parse_arguments()

--- a/phold/submit.py
+++ b/phold/submit.py
@@ -319,7 +319,7 @@ def generate_phold_args(node_counts=[1], thread_counts=[1], rank_counts=[1],
        (event_density, ring_size, time_to_run, small_payload, large_payload, 
         large_event_fraction, imbalance_factor, component_size, component_computation)) in parameter_tuples:
     srun_args = f"--nodes={node_count} --cpus-per-task={thread_count} --ntasks-per-node={rank_count}"
-    sst_args = f"--threads={thread_count}"
+    sst_args = f"--num-threads={thread_count}"
     phold_args = f"--height {height} --width {width} --eventDensity {event_density} --timeToRun {time_to_run}ns --numRings {ring_size} --smallPayload {small_payload} --largePayload {large_payload} --largeEventFraction {large_event_fraction} --imbalance-factor {imbalance_factor} --componentSize {component_size} --componentComputation {component_computation}"
     run_name = f"{name}_{node_count}_{rank_count}_{thread_count}_{width}_{height}_{event_density}_{ring_size}_{time_to_run}_{small_payload}_{large_payload}_{large_event_fraction}_{imbalance_factor}_{component_size}_{component_computation}"
     arg_tuples.append((srun_args, sst_args, phold_args, run_name))

--- a/phold/workflow_extractors.py
+++ b/phold/workflow_extractors.py
@@ -1,0 +1,234 @@
+# This file contains functions useful in notebook-only workflows for extracting results from PHOLD benchmark outputs.
+
+import os
+import humanfriendly
+from concurrent.futures import ThreadPoolExecutor
+import numpy as np
+
+def extract_failure_reason(output_filename):
+  """
+  Extract the failure reason from the srun output file.
+
+  :arg: output_filename: The path to the srun output file. This should contain the output from srun as well as the output of the job
+  """
+  if not os.path.exists(output_filename):
+    return "No output file found."
+
+  with open(output_filename, 'r') as f:
+    lines = f.readlines()
+  
+  for line in lines:
+    if "DUE TO TIME LIMIT" in line:
+      return "Timeout"
+    elif "inet_connect" in line:
+      return "Network Socket Failure"
+    elif "LE resources not recovered during flow control. FI_CXI_RX_MATCH_MODE=[hybrid|software] is required" in line:
+      return "Network Fabric Failure"
+    elif 'MPICH ERROR' in line:
+      return "MPI Failure"
+    elif "DUE TO TASK FAILURE" in line:
+      return "Out of Memory"
+
+  return "Other Failure"
+
+
+# Checks that a directory contains the necessary files for data extraction to occur
+def check_valid_result_dir(result_dir):
+    # Check the directory exists to begin with
+    if not os.path.isdir(result_dir):
+        
+        return False
+    # Check that there's at least one sync file
+    sync_files = [
+        file_name for file_name in os.listdir(result_dir)
+        if file_name.startswith('rank')
+    ]
+    if not sync_files:
+       
+        return False
+    # Check that there's a run.log
+    if 'run.log' not in os.listdir(result_dir):
+        return False
+    
+    # Check the contents of the run.log
+    if extract_failure_reason(os.path.join(result_dir, 'run.log')) != "Other Failure":
+       return False
+    return True
+
+# Parse a single sync file. Helper function used by extract_sync_data to process files in parallel.
+def _parse_sync_file(file_path):
+    try:
+        with open(file_path, 'r') as f:
+            lines = f.readlines()
+        thread_count_line = lines[-11]
+        thread_time_line = lines[-10]
+        thread_count = int(thread_count_line.split(':')[1].strip())
+        thread_time = float(thread_time_line.split(' ')[-2].strip())
+        rank_count_line = lines[-7]
+        rank_time_line = lines[-6]
+        rank_count = int(rank_count_line.split(':')[1].strip())
+        rank_time = float(rank_time_line.split(' ')[-2].strip())
+        return (thread_count, thread_time, rank_count, rank_time)
+    except:
+        return None  # skip malformed or incomplete files
+
+def extract_sync_data(result_dir):
+    sync_files = [
+        os.path.join(result_dir, file_name)
+        for file_name in os.listdir(result_dir)
+        if file_name.startswith('rank')
+    ]
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = executor.map(_parse_sync_file, sync_files)
+
+    sync_data = [r for r in results if r is not None]
+
+    if not sync_data:
+        return {}
+
+    thread_sync_counts = [count for count, _, _, _ in sync_data]
+    thread_sync_times = [time for _, time, _, _ in sync_data]
+    rank_sync_counts = [count for _, _, count, _ in sync_data]
+    rank_sync_times = [time for _, _, _, time in sync_data]
+
+    return {
+        'Rank Sync Time Max (s)': np.max(rank_sync_times),
+        'Rank Sync Time Min (s)': np.min(rank_sync_times),
+        'Rank Sync Time Mean (s)': np.mean(rank_sync_times),
+        'Rank Sync Time Std (s)': np.std(rank_sync_times),
+        'Rank Sync Count Max': np.max(rank_sync_counts),
+        'Rank Sync Count Min': np.min(rank_sync_counts),
+        'Rank Sync Count Mean': np.mean(rank_sync_counts),
+        'Rank Sync Count Std': np.std(rank_sync_counts),
+        'Thread Sync Time Max (s)': np.max(thread_sync_times),
+        'Thread Sync Time Min (s)': np.min(thread_sync_times),
+        'Thread Sync Time Mean (s)': np.mean(thread_sync_times),
+        'Thread Sync Time Std (s)': np.std(thread_sync_times),
+        'Thread Sync Count Max': np.max(thread_sync_counts),
+        'Thread Sync Count Min': np.min(thread_sync_counts),
+        'Thread Sync Count Mean': np.mean(thread_sync_counts),
+        'Thread Sync Count Std': np.std(thread_sync_counts)
+    }
+
+
+# Extracts timing and memory usage data from log files from SST 15.0.0 runs.
+def extract_time_data_15_0_0(result_dir):
+  log_file = os.path.join(result_dir, 'run.log')
+  with open(log_file, 'r') as f:
+    lines = f.readlines()
+    time_data = {}
+    for line in lines:
+      if 'Build time:' in line:
+        time_data['Build Time (s)'] = float(line.split(':')[1].strip().split()[0])
+      elif 'Run loop time:' in line:
+        time_data['Run Time (s)'] = float(line.split(':')[1].strip().split()[0])
+      elif 'Max Resident Set Size:' in line:
+         time_data['Max Resident Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
+      elif 'Global Max RSS Size:' in line:
+         time_data['Max Global Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
+  return time_data
+
+# Extracts timing and memory usage data from log files from SST >15.0.0 runs.
+def extract_time_data_g15(result_dir):
+  log_file = os.path.join(result_dir, 'run.log')
+  with open(log_file, 'r') as f:
+    lines = f.readlines()
+    time_data = {}
+    for line in lines:
+      if '├ ■ build' in line:
+        # take the next line
+        build_time_line = lines[lines.index(line) + 1]
+        time_data['Build Time (s)'] = float(build_time_line.split(':')[1].strip().split()[0])
+      elif '■ execute' in line:
+        # take the next line
+        run_time_line = lines[lines.index(line) + 1]
+        time_data['Run Time (s)'] = float(run_time_line.split(':')[1].strip().split()[0])
+      elif 'Max Resident Set Size:' in line:
+         time_data['Max Resident Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
+      elif 'Global Max RSS Size:' in line:
+         time_data['Max Global Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
+  return time_data
+
+def extract_time_data(result_dir, version):
+    if version == '15.0.0':
+        return extract_time_data_15_0_0(result_dir)
+    else:
+        return extract_time_data_g15(result_dir)
+    
+def extract_parameters(result_dir):
+  '''
+  Extract parameters from the run name, which is the last part of the path
+  '''
+  run_name = os.path.basename(result_dir)
+  parts = run_name.split('_')
+  return {
+      'Experiment Name': parts[0],
+      'Node Count': int(parts[1]),
+      'Ranks Per Node': int(parts[2]),
+      'Threads Per Rank': int(parts[3]),
+      'Width': int(parts[4]),
+      'Height': int(parts[5]),
+      'Event Density': float(parts[6]),
+      'Ring Size': int(parts[7]),
+      'Time to Run (ns)': int(parts[8]),
+      'Small Payload (bytes)': int(parts[9]),
+      'Large Payload (bytes)': int(parts[10]),
+      'Large Event Fraction': float(parts[11]),
+      'Imbalance Factor': float(parts[12]),
+      'Component Size (bytes)': int(parts[13]) if len(parts) > 13 else 0,
+      'Component Computations': int(parts[14]) if len(parts) > 14 else 0
+  }
+
+
+def identify_result_dirs(search_dir, experiment_name=None):
+    """
+    Identify directories containing result files.
+    """
+    result_dirs = []
+    invalid_dirs = []
+    for item in os.listdir(search_dir):
+        item_path = os.path.join(search_dir, item)
+
+        if experiment_name is not None and not item.startswith(experiment_name):
+            continue
+        has_output_file = any(file.endswith('run.log') for file in os.listdir(item_path))
+        has_rank_files = any(file.startswith('rank') for file in os.listdir(item_path))
+
+        if not has_output_file:
+            invalid_dirs.append((item, "Missing run.log file"))
+        elif not has_rank_files:
+            invalid_dirs.append((item, "Missing rank files"))
+        else:
+            result_dirs.append(item)
+        
+    return (result_dirs, invalid_dirs)
+
+def extract_single_result(results_dir, sst_version):
+    parameters = extract_parameters(results_dir)
+    time_data = extract_time_data(results_dir, sst_version)
+    if len(time_data) != 4:
+        raise ValueError(f"Expected to extract 4 time/memory data points, but got {len(time_data)}. Data: {time_data}")
+    sync_data = extract_sync_data(results_dir)
+    return {**parameters, **time_data, **sync_data, 'SST Version': sst_version}
+
+def extract_results(results_dir, sst_version):
+    successes = []
+    failures = []
+    valid_dirs, invalid_dirs = identify_result_dirs(results_dir)
+    for valid_dir in valid_dirs:
+        try:
+            result = extract_single_result(os.path.join(results_dir, valid_dir), sst_version)
+            result['Status'] = 'Success'
+            successes.append(result)
+        except Exception as e:
+            invalid_dirs.append((valid_dir, f"Error during data extraction: {e}"))
+            
+    for (invalid_dir, reason) in invalid_dirs:
+        parameters = extract_parameters(os.path.join(results_dir, invalid_dir))
+        output_filepath = os.path.join(results_dir, invalid_dir, 'run.log')
+        if os.path.exists(output_filepath):
+            reason = extract_failure_reason(output_filepath)
+        parameters.update({'Status': 'Failure', 'Failure Reason': reason, 'SST Version': sst_version})
+        failures.append(parameters)
+    return successes, failures

--- a/phold/workflow_extractors.py
+++ b/phold/workflow_extractors.py
@@ -31,30 +31,6 @@ def extract_failure_reason(output_filename):
 
   return "Other Failure"
 
-
-# Checks that a directory contains the necessary files for data extraction to occur
-def check_valid_result_dir(result_dir):
-    # Check the directory exists to begin with
-    if not os.path.isdir(result_dir):
-        
-        return False
-    # Check that there's at least one sync file
-    sync_files = [
-        file_name for file_name in os.listdir(result_dir)
-        if file_name.startswith('rank')
-    ]
-    if not sync_files:
-       
-        return False
-    # Check that there's a run.log
-    if 'run.log' not in os.listdir(result_dir):
-        return False
-    
-    # Check the contents of the run.log
-    if extract_failure_reason(os.path.join(result_dir, 'run.log')) != "Other Failure":
-       return False
-    return True
-
 # Parse a single sync file. Helper function used by extract_sync_data to process files in parallel.
 def _parse_sync_file(file_path):
     try:
@@ -73,6 +49,8 @@ def _parse_sync_file(file_path):
         return None  # skip malformed or incomplete files
 
 def extract_sync_data(result_dir):
+    """Extracts and consolidates per-thread synchronization time data
+    """
     sync_files = [
         os.path.join(result_dir, file_name)
         for file_name in os.listdir(result_dir)
@@ -113,25 +91,33 @@ def extract_sync_data(result_dir):
 
 
 # Extracts timing and memory usage data from log files from SST 15.0.0 runs.
-def extract_time_data_15_0_0(result_dir):
-  log_file = os.path.join(result_dir, 'run.log')
-  with open(log_file, 'r') as f:
-    lines = f.readlines()
-    time_data = {}
-    for line in lines:
-      if 'Build time:' in line:
-        time_data['Build Time (s)'] = float(line.split(':')[1].strip().split()[0])
-      elif 'Run loop time:' in line:
-        time_data['Run Time (s)'] = float(line.split(':')[1].strip().split()[0])
-      elif 'Max Resident Set Size:' in line:
-         time_data['Max Resident Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
-      elif 'Global Max RSS Size:' in line:
-         time_data['Max Global Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
-  return time_data
+def extract_time_data_eq15(result_dir, logfile_name='run.log'):
+    """Extracts timing and memory usage data from log files from runs executed with SST version 15.0.0."""
+    log_file = os.path.join(result_dir, logfile_name)
+    with open(log_file, 'r') as f:
+        lines = f.readlines()
+        time_data = {}
+        for line in lines:
+            if 'Build time:' in line:
+                time_data['Build Time (s)'] = float(
+                    line.split(':')[1].strip().split()[0])
+            elif 'Run loop time:' in line:
+                time_data['Run Time (s)'] = float(
+                    line.split(':')[1].strip().split()[0])
+            elif 'Max Resident Set Size:' in line:
+                time_data['Max Resident Set Size (bytes)'] = humanfriendly.parse_size(
+                    line.split(':')[1].strip())
+            elif 'Global Max RSS Size:' in line:
+                time_data['Max Global Set Size (bytes)'] = humanfriendly.parse_size(
+                    line.split(':')[1].strip())
+    return time_data
 
 # Extracts timing and memory usage data from log files from SST >15.0.0 runs.
-def extract_time_data_g15(result_dir):
-  log_file = os.path.join(result_dir, 'run.log')
+
+
+def extract_time_data_g15(result_dir, logfile_name='run.log'):
+  """Extracts timing and memory usage data from log files from runs executed with SST versions greater than 15.0.0."""
+  log_file = os.path.join(result_dir, logfile_name)
   with open(log_file, 'r') as f:
     lines = f.readlines()
     time_data = {}
@@ -139,26 +125,29 @@ def extract_time_data_g15(result_dir):
       if '├ ■ build' in line:
         # take the next line
         build_time_line = lines[lines.index(line) + 1]
-        time_data['Build Time (s)'] = float(build_time_line.split(':')[1].strip().split()[0])
+        time_data['Build Time (s)'] = float(
+            build_time_line.split(':')[1].strip().split()[0])
       elif '■ execute' in line:
         # take the next line
         run_time_line = lines[lines.index(line) + 1]
-        time_data['Run Time (s)'] = float(run_time_line.split(':')[1].strip().split()[0])
+        time_data['Run Time (s)'] = float(
+            run_time_line.split(':')[1].strip().split()[0])
       elif 'Max Resident Set Size:' in line:
-         time_data['Max Resident Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
+         time_data['Max Resident Set Size (bytes)'] = humanfriendly.parse_size(
+             line.split(':')[1].strip())
       elif 'Global Max RSS Size:' in line:
-         time_data['Max Global Set Size (bytes)'] = humanfriendly.parse_size(line.split(':')[1].strip())
+         time_data['Max Global Set Size (bytes)'] = humanfriendly.parse_size(
+             line.split(':')[1].strip())
   return time_data
 
 def extract_time_data(result_dir, version):
     if version == '15.0.0':
-        return extract_time_data_15_0_0(result_dir)
+        return extract_time_data_eq15(result_dir)
     else:
         return extract_time_data_g15(result_dir)
     
 def extract_parameters(result_dir):
-  '''
-  Extract parameters from the run name, which is the last part of the path
+  '''Extract parameters from the run name, which is the last part of the path
   '''
   run_name = os.path.basename(result_dir)
   parts = run_name.split('_')
@@ -180,45 +169,107 @@ def extract_parameters(result_dir):
       'Component Computations': int(parts[14]) if len(parts) > 14 else 0
   }
 
-
-def identify_result_dirs(search_dir, experiment_name=None):
+def extract_single_result(result_dir, sst_version, logfile_name='run.log'):
+    """Extracts output results and run parameters from the result of a PHOLD simulation.
+    
+    This function assumes that the `result_dir` path has already been checked to be a valid result directory.
+        Exceptions thrown during processing are assumed to indicate a invalid or incomplete run, and are to be 
+        handled by the caller of this function.
+    
+    Args:
+        result_dir: The path to the directory containing the results of a single PHOLD simulation run. 
+            This directory should contain a log file with timing and memory usage data, as well as one
+            or more synchronization files starting with 'rank'.
+        sst_version: The version of SST used for the simulation run, which determines how timing data is extracted.
+        logfile_name: The name of the log file to look for in the result directory. Default is 'run.log'.
+        
+    Returns:
+        dict: A dictionary containing the extracted results and parameters.
     """
-    Identify directories containing result files.
+    parameters = extract_parameters(result_dir)
+    time_data = extract_time_data(result_dir, sst_version)
+    if len(time_data) != 4:
+        raise ValueError(f"Expected to extract 4 time/memory data points, but got {len(time_data)}. Data: {time_data}")
+    sync_data = extract_sync_data(result_dir)
+    return {**parameters, **time_data, **sync_data, 'SST Version': sst_version}
+
+def identify_result_dirs(search_dir, logfile_name, experiment_name=None):
+    """ Identify directories containing result files.
+
+    This function crawls the given `search_dir` for subdirectories that contain
+        the necessary files for data extraction, specifically a log file with 
+        the name specified by `logfile_name` and one or more synchronization files
+        starting with 'rank'. If `experiment_name` is provided, only subdirectories
+        whose names start with the given experiment name will be considered.
+
+    Args:
+        search_dir (str): The directory to search for result subdirectories.
+        logfile_name (str): The name of the log file to look for in each subdirectory
+        experiment_name (str, optional): If provided, only subdirectories starting with 
+            this string will be considered. Default is None, meaning all subdirectories 
+            will be considered.
+    
+    Returns:
+        tuple: A tuple containing two lists:
+            - valid_dirs: A list of subdirectory names that contain the necessary files for data extraction
+            - invalid_dirs: A list of tuples, each containing a subdirectory name and a reason why 
+                it was considered invalid (e.g., missing log file, missing sync files, etc.)
     """
     result_dirs = []
     invalid_dirs = []
-    for item in os.listdir(search_dir):
-        item_path = os.path.join(search_dir, item)
 
-        if experiment_name is not None and not item.startswith(experiment_name):
+    for candidate in os.listdir(search_dir):
+        candidate_path = os.path.join(search_dir, candidate)
+
+        # Skip non-directories
+        if not os.path.isdir(candidate_path):
             continue
-        has_output_file = any(file.endswith('run.log') for file in os.listdir(item_path))
-        has_rank_files = any(file.startswith('rank') for file in os.listdir(item_path))
+        # Skip if there's a experiment name filter and this candidate doesn't match
+        if experiment_name is not None and not candidate.startswith(experiment_name):
+            continue
+
+        # Check for a log file and at least one sync file
+        has_output_file = any(file.endswith('run.log') for file in os.listdir(candidate_path))
+        has_rank_files = any(file.startswith('rank') for file in os.listdir(candidate_path))
 
         if not has_output_file:
-            invalid_dirs.append((item, "Missing run.log file"))
+            invalid_dirs.append((candidate, "Missing run.log file"))
         elif not has_rank_files:
-            invalid_dirs.append((item, "Missing rank files"))
+            invalid_dirs.append((candidate, "Missing rank files"))
         else:
-            result_dirs.append(item)
+            result_dirs.append(candidate)
         
     return (result_dirs, invalid_dirs)
 
-def extract_single_result(results_dir, sst_version):
-    parameters = extract_parameters(results_dir)
-    time_data = extract_time_data(results_dir, sst_version)
-    if len(time_data) != 4:
-        raise ValueError(f"Expected to extract 4 time/memory data points, but got {len(time_data)}. Data: {time_data}")
-    sync_data = extract_sync_data(results_dir)
-    return {**parameters, **time_data, **sync_data, 'SST Version': sst_version}
+def extract_results(results_dir, sst_version, logfile_name='run.log', experiment_name=None):
+    """Extracts PHOLD simulation results from a directory containing multiple run subdirectories.
+    
+    The `results_dir` argument should be the full path to a directory containing subdirectories for each simulation
+        run. Each run subdirectory should be named according to the paremeter encoding sceme defined in `extract_parameters` and
+        produced by the `generate_phold_args` function in the `submit.py` script. The run subdirectory should contain a file with 
+        the same name as the `logfile_name` argument, by default `run.log`, as well as one or more `rank*.log` files containing 
+        synchronization data.
+    
 
-def extract_results(results_dir, sst_version):
+    Args:
+        results_dir (str): The path to the directory containing subdirectories for each simulation run.
+        sst_version (str): The version of SST used for the runs, which determines how time data is extracted.
+        logfile_name (str): The name of the log file to look for in each run subdirectory. Default is 'run.log'.
+        experiment_name (str, optional): If provided, only subdirectories starting with this string will be processed. Default is None, meaning all subdirectories will be processed.
+        
+    Returns:
+        tuple: A tuple containing two lists:
+            - successes: A list of dictionaries, each containing extracted data for a successful run.
+            - failures: A list of dictionaries, each containing parameters and failure reasons for failed runs."""
     successes = []
     failures = []
-    valid_dirs, invalid_dirs = identify_result_dirs(results_dir)
+    valid_dirs, invalid_dirs = identify_result_dirs(results_dir, logfile_name, experiment_name=experiment_name)
+    
+    # Process the valid dirs, if there's a problem, add to the invalid dirs
     for valid_dir in valid_dirs:
         try:
-            result = extract_single_result(os.path.join(results_dir, valid_dir), sst_version)
+            result_dir = os.path.join(results_dir, valid_dir)
+            result = extract_single_result(result_dir, sst_version, logfile_name=logfile_name)
             result['Status'] = 'Success'
             successes.append(result)
         except Exception as e:
@@ -226,7 +277,7 @@ def extract_results(results_dir, sst_version):
             
     for (invalid_dir, reason) in invalid_dirs:
         parameters = extract_parameters(os.path.join(results_dir, invalid_dir))
-        output_filepath = os.path.join(results_dir, invalid_dir, 'run.log')
+        output_filepath = os.path.join(results_dir, invalid_dir, logfile_name)
         if os.path.exists(output_filepath):
             reason = extract_failure_reason(output_filepath)
         parameters.update({'Status': 'Failure', 'Failure Reason': reason, 'SST Version': sst_version})

--- a/phold/workflow_extractors.py
+++ b/phold/workflow_extractors.py
@@ -229,11 +229,11 @@ def identify_result_dirs(search_dir, logfile_name, experiment_name=None):
             continue
 
         # Check for a log file and at least one sync file
-        has_output_file = any(file.endswith('run.log') for file in os.listdir(candidate_path))
+        has_output_file = any(file.endswith(logfile_name) for file in os.listdir(candidate_path))
         has_rank_files = any(file.startswith('rank') for file in os.listdir(candidate_path))
 
         if not has_output_file:
-            invalid_dirs.append((candidate, "Missing run.log file"))
+            invalid_dirs.append((candidate, f"Missing {logfile_name} file"))
         elif not has_rank_files:
             invalid_dirs.append((candidate, "Missing rank files"))
         else:

--- a/phold/workflow_processing.py
+++ b/phold/workflow_processing.py
@@ -4,22 +4,30 @@ from plotnine import *
 pd.set_option("display.max_columns", 100)
 
 def parameter_columns(): 
+  """Returns a list of the DataFrame columns that contain input parameters
+  """
   return ['Experiment Name', 'Node Count', 'Ranks Per Node', 'Thread Count',
        'Width', 'Height', 'Event Density', 'Ring Size', 'Time to Run (ns)',
        'Small Payload (bytes)', 'Large Payload (bytes)',
-       'Large Event Fraction', 'Imbalance Factor', 'Component Size']
+       'Large Event Fraction', 'Imbalance Factor', 'Component Size', 'Component Computation']
 
 def varied_parameters(data):
+  """Identifies parameters that have variable values within the DataFrame
+  """
   mask = data[data.columns.intersection(parameter_columns())].nunique() > 1
   return  mask.index[mask].tolist()
 
 def memory_columns():
+  """Returns the name of the columns that have to do with memory usage
+  """
   return ['Max Local Memory Usage (GiB)',
        'Max Global Memory Usage (GiB)', 'SLURM Allocated Memory (GiB)',
        'Max Local Memory Utilization (%)', 'Max Global Memory Utilization (%)']
 
   
 def measurement_columns():
+  """Returns a list of the column names that are measured output values. This does not include calculated metrics
+  """
   return ['Build Time (s)', 'Run Time (s)', 'Max Resident Set Size (bytes)',
        'Max Global Set Size (bytes)', 'Rank Sync Time Max (s)',
        'Rank Sync Time Min (s)', 'Rank Sync Time Mean (s)',
@@ -32,6 +40,8 @@ def measurement_columns():
        'Status']
 
 def calculated_columns():
+  """Returns a list of the column names that are calculated output columns.
+  """
   return ['Rank Count', 'Total Threads', 'Threads Per Node', 'Components', 'Million Components',
        'Components Per Node', 'Million Components Per Node', 'StencilLength',
        'Total Links', 'Boundary Count', 'Remote Links', 'Remote Links (Ranks)',
@@ -64,6 +74,7 @@ def read_all_csvs(directory):
   return pd.concat(dataframes, ignore_index=True)
 
 def triangular(n):
+  """Calculates the nth triangular number, which is used to calculate the link count"""
   return n * (n + 1) // 2
 
    
@@ -114,16 +125,22 @@ def height_from_fraction(target_fraction, ring_size, width, boundary_count):
   return height
 
 def fill_missing_fields(data):
+  """Adds fields to the DataFrame to allow for compatibility with different versions of PHOLD
+  """
   if 'Small Payload (bytes)' not in data.columns:
     data['Small Payload (bytes)'] = 0
   if 'Large Payload (bytes)' not in data.columns:
     data['Large Payload (bytes)'] = 0
   if 'Large Event Fraction' not in data.columns:
     data['Large Event Fraction'] = 0
+  if 'Component Computation' not in data.columns:
+    data['Component Computation'] = 0
   return data
 
 
 def mem_based_fields(data):
+  """Calculates memory-based fields, including GiB based usage metrics, total allocations, and utilization based on 512GiB system
+  """
   data['Max Local Memory Usage (GiB)'] = data['Max Resident Set Size (bytes)'] / (1024.0 ** 3)
   data['Max Global Memory Usage (GiB)'] = data['Max Global Set Size (bytes)'] / (1024.0 ** 3)
   data['SLURM Allocated Memory (GiB)'] = 512.0 * data['Node Count'] # hotlum
@@ -131,7 +148,11 @@ def mem_based_fields(data):
   data['Max Global Memory Utilization (%)'] = 100 * data['Max Global Memory Usage (GiB)'] / data['SLURM Allocated Memory (GiB)']
 
   return data
+
+
 def time_based_fields(data):
+  """Calculates fields related to time spent in various parts of the simulation
+  """
   if 'Sync Time Mean (s)' not in data.columns:
     data['Sync Time Mean (s)'] = data['Rank Sync Time Mean (s)'] + data['Thread Sync Time Mean (s)']
   if 'Sync Time Max (s)' not in data.columns:
@@ -151,7 +172,6 @@ def time_based_fields(data):
   data['Events/Second Total'] = data['Event Count'] / (data['Run Time (s)'] + data['Build Time (s)'])
   data['Million Events Per Second Total'] = data['Events/Second Total'] / 1e6
 
-
   data['SyncFraction'] = '0% to 10%'
   data.loc[data['Mean Sync Time Fraction (%)'] >= 10, 'SyncFraction'] = '10% to 20%'
   data.loc[data['Mean Sync Time Fraction (%)'] >= 20, 'SyncFraction'] = '20% to 30%'
@@ -164,6 +184,8 @@ def time_based_fields(data):
 
 
 def topology_fields(data):
+  """Calculates fields related to the topology of the simulation"""
+  
   if 'Ranks Per Node' in data.columns:
     data['Rank Count'] = data['Node Count'] * data['Ranks Per Node']
   if 'Thread Count' in data.columns:
@@ -219,13 +241,16 @@ def topology_fields(data):
   return data
 
 def add_aliases(data):
-
+  """Adds a couple of column aliases"""
   data['Nodes'] = data['Node Count']
   data['Density'] = data['Event Density']
   data['Remote Event Fraction (%)'] = data['Remote Link Fraction (%)']
   return data
 
 def clean_and_calculate(data):
+  """This function is the main function to prepare extracted data for analysis. 
+     This is to be used on the dataframe of successful runs
+  """
   data = fill_missing_fields(data)
   
   data = topology_fields(data)
@@ -237,6 +262,9 @@ def clean_and_calculate(data):
   return data
 
 def clean_failures(data):
+  """
+  The main function to be used to prepare a dataframe of failed runs for processing
+  """
   data = fill_missing_fields(data)
   
   data = topology_fields(data)


### PR DESCRIPTION
## Summary
This branch adds support for modeling per-event component compute intensity in PHOLD and introduces notebook-friendly workflow extraction/processing modules.

## What Changed

Existing Benchmark and Tooling
- Added `componentComputation` parameter in submission script to run extra RNG-based computation during event handling.
- Added componentComputeCount field and componentCompute() method in `Node` component.
- Integrated the new compute step into `handleEvent`.
- Updated `dispatch.sh` and `submit.py` to support `component-computation` arguments

New Tooling
- Added new notebook workflow modules: `workflow_extractors.py` and `workflow_processing.py` for use in notebook-only workflows
- Added `generate_phold_args` method to `submit.py` to support generating arguments for notebook invocations of the PHOLD benchmark.

Documentation
- Updated README with new parameter docs, workflow usage examples, and improved section headings.