### PR TITLE
Cyclical reference POC

### DIFF
--- a/cyclical_reference/Child.cpp
+++ b/cyclical_reference/Child.cpp
@@ -59,6 +59,9 @@ void basicSubComponentIncrement::serialize_order(SST::Core::Serialization::seria
     SubComponent::serialize_order(ser);
 
     SST_SER(amount);
+    SST_SER(link_name);
+    SST_SER(parent);
+    SST_SER(link);
 }
 
 void basicSubComponentIncrement::handleEvent(SST::Event* ev) {
@@ -68,13 +71,22 @@ void basicSubComponentIncrement::handleEvent(SST::Event* ev) {
     int received_value = std::stoi(payloadEv->getString());
     
     std::cout << "Received event with value " << received_value << " on link " << link_name << std::endl;
-    parent->out->output("%s SubComponent of %s received event with value %d. Remaining on parent: %d. Subcomponent amount: %d\n", link_name.c_str(), getName().c_str(), received_value, this->parent->value, amount);
+    std::cout << "Computing new value with amount " << amount << std::endl;
+    std::cout << "Accessing parent: " << this->parent->value << std::endl;
+    std::cout << "ACcessing link name: " << link_name << std::endl;
+    std::cout << "Calling getName(): " << getName() << std::endl;
+    std::cout << "Using paret->out" << std::endl;
+    getSimulationOutput().output("string");
+    std::cout << "used parent->out";
+    getSimulationOutput().output("%s SubComponent of %s received event with value %d. Remaining on parent: %d. Subcomponent amount: %d\n", link_name.c_str(), getName().c_str(), received_value, this->parent->value, amount);
    
     int new_value = compute(received_value); // this will change this component's state
 
     
     SST::Interfaces::StringEvent* new_ev = new SST::Interfaces::StringEvent(std::to_string(new_value));
     delete ev;
+    // print the address of the parent pointer
+    std::cout << "Parent pointer address: " << parent << std::endl;
     parent->continuePassing(new_ev);
     
 }
@@ -86,5 +98,5 @@ void basicSubComponentIncrement::sendEvent(SST::Event* ev) {
 }
 
 void basicSubComponentIncrement::finish() {
-    parent->out->output("%s SubComponent of %s is finishing. Final amount: %d\n", link_name.c_str(), getName().c_str(), amount);
+    getSimulationOutput().output("%s SubComponent of %s is finishing. Final amount: %d\n", link_name.c_str(), getName().c_str(), amount);
 }

--- a/cyclical_reference/Child.cpp
+++ b/cyclical_reference/Child.cpp
@@ -46,12 +46,13 @@ basicSubComponentIncrement::~basicSubComponentIncrement() { }
 
 int basicSubComponentIncrement::compute( int num )
 {
-    return num + amount;
+    return num + amount++;
+
 }
 
 std::string basicSubComponentIncrement::compute ( std::string comp )
 {
-    return "(" + comp + ")" + " + " + std::to_string(amount);
+    return "(" + comp + ")" + " + " + std::to_string(amount++);
 }
 
 void basicSubComponentIncrement::serialize_order(SST::Core::Serialization::serializer& ser) {
@@ -65,10 +66,16 @@ void basicSubComponentIncrement::handleEvent(SST::Event* ev) {
         dynamic_cast<SST::Interfaces::StringEvent*>(ev);
 
     int received_value = std::stoi(payloadEv->getString());
+    
     std::cout << "Received event with value " << received_value << " on link " << link_name << std::endl;
-    parent->out->output("SubComponent %s received event with received_value %d. Remaining: %d\n", getName().c_str(), received_value, this->parent->value);
+    parent->out->output("%s SubComponent of %s received event with value %d. Remaining on parent: %d. Subcomponent amount: %d\n", link_name.c_str(), getName().c_str(), received_value, this->parent->value, amount);
    
-    parent->continuePassing(ev);
+    int new_value = compute(received_value); // this will change this component's state
+
+    
+    SST::Interfaces::StringEvent* new_ev = new SST::Interfaces::StringEvent(std::to_string(new_value));
+    delete ev;
+    parent->continuePassing(new_ev);
     
 }
 
@@ -76,4 +83,8 @@ void basicSubComponentIncrement::sendEvent(SST::Event* ev) {
     std::cout << "Sending event with value " << dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString() << " on link " << link_name << std::endl;
     link->send(ev);
     std::cout << "Event sent with value " << dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString() << " on link " << link_name << std::endl;
+}
+
+void basicSubComponentIncrement::finish() {
+    parent->out->output("%s SubComponent of %s is finishing. Final amount: %d\n", link_name.c_str(), getName().c_str(), amount);
 }

--- a/cyclical_reference/Child.cpp
+++ b/cyclical_reference/Child.cpp
@@ -26,77 +26,57 @@
 using namespace SST;
 using namespace SST::cyclical;
 
-/***********************************************************************************/
-// Since the classes are brief, this file has the implementation for all four
-// basicSubComponentAPI subcomponents declared in basicSubComponent_subcomponent.h
-/***********************************************************************************/
 
-// basicSubComponentIncrement
-
-basicSubComponentIncrement::basicSubComponentIncrement(ComponentId_t id, Params& params, basicSubComponent_Component* parent, std::string link_name) 
+basicSubComponent::basicSubComponent(ComponentId_t id, Params& params, ParentComponent* parent, std::string link_name) 
     : basicSubComponentAPI(id, params, parent, link_name), parent(parent), link_name(link_name)
 {
     amount = params.find<int>("amount",  1);
-    link = configureLink(link_name, new Event::Handler2<basicSubComponentIncrement, &basicSubComponentIncrement::handleEvent>(this));
-        sst_assert(link, CALL_INFO, -1,
-                "Error: SubComponent %s has an incorrectly configured link on port '%s'\n", getName().c_str(), link_name.c_str());
+    link = configureLink(link_name, 
+        new Event::Handler2<basicSubComponent, &basicSubComponent::handleEvent>(this));
+    sst_assert(link, CALL_INFO, -1,
+        "Error: SubComponent %s has an incorrectly configured link on port '%s'\n", 
+        getName().c_str(), link_name.c_str());
 }
 
-basicSubComponentIncrement::~basicSubComponentIncrement() { }
+basicSubComponent::~basicSubComponent() { }
 
-int basicSubComponentIncrement::compute( int num )
-{
-    return num + amount++;
-
-}
-
-std::string basicSubComponentIncrement::compute ( std::string comp )
-{
-    return "(" + comp + ")" + " + " + std::to_string(amount++);
-}
-
-void basicSubComponentIncrement::serialize_order(SST::Core::Serialization::serializer& ser) {
-    SubComponent::serialize_order(ser);
-
-    SST_SER(amount);
-    SST_SER(link_name);
-    SST_SER(parent);
-    SST_SER(link);
-}
-
-void basicSubComponentIncrement::handleEvent(SST::Event* ev) {
+void basicSubComponent::handleEvent(SST::Event* ev) {
     SST::Interfaces::StringEvent* payloadEv = 
         dynamic_cast<SST::Interfaces::StringEvent*>(ev);
 
     int received_value = std::stoi(payloadEv->getString());
     
-    std::cout << "Received event with value " << received_value << " on link " << link_name << std::endl;
-    std::cout << "Computing new value with amount " << amount << std::endl;
-    std::cout << "Accessing parent: " << this->parent->value << std::endl;
-    std::cout << "ACcessing link name: " << link_name << std::endl;
-    std::cout << "Calling getName(): " << getName() << std::endl;
-    std::cout << "Using paret->out" << std::endl;
-    getSimulationOutput().output("string");
-    std::cout << "used parent->out";
-    getSimulationOutput().output("%s SubComponent of %s received event with value %d. Remaining on parent: %d. Subcomponent amount: %d\n", link_name.c_str(), getName().c_str(), received_value, this->parent->value, amount);
+    getSimulationOutput().output(
+        "%s SubComponent of %s received event with value %d. " 
+        "Remaining on parent: %d. Subcomponent amount: %d\n", 
+        link_name.c_str(), getName().c_str(), received_value, this->parent->value, amount);
    
-    int new_value = compute(received_value); // this will change this component's state
+    int new_value = received_value + amount++; // changes the state of the subcomponent
 
-    
     SST::Interfaces::StringEvent* new_ev = new SST::Interfaces::StringEvent(std::to_string(new_value));
-    delete ev;
-    // print the address of the parent pointer
-    std::cout << "Parent pointer address: " << parent << std::endl;
-    parent->continuePassing(new_ev);
     
+    delete ev;
+
+    // Sends the newly created event up to the parent component, which will
+    // then update its own state and send the event to the its neighbor
+    parent->computeAndSend(new_ev);
 }
 
-void basicSubComponentIncrement::sendEvent(SST::Event* ev) {
-    std::cout << "Sending event with value " << dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString() << " on link " << link_name << std::endl;
+void basicSubComponent::sendEvent(SST::Event* ev) {
     link->send(ev);
-    std::cout << "Event sent with value " << dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString() << " on link " << link_name << std::endl;
 }
 
-void basicSubComponentIncrement::finish() {
-    getSimulationOutput().output("%s SubComponent of %s is finishing. Final amount: %d\n", link_name.c_str(), getName().c_str(), amount);
+void basicSubComponent::finish() {
+    getSimulationOutput().output(
+        "%s SubComponent of %s is finishing. Final amount: %d\n", 
+        link_name.c_str(), getName().c_str(), amount);
+}
+
+
+void basicSubComponent::serialize_order(SST::Core::Serialization::serializer& ser) {
+    SubComponent::serialize_order(ser);
+    SST_SER(amount);
+    SST_SER(link_name);
+    SST_SER(parent);
+    SST_SER(link);
 }

--- a/cyclical_reference/Child.cpp
+++ b/cyclical_reference/Child.cpp
@@ -1,0 +1,56 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+// This include is ***REQUIRED***
+// for ALL SST implementation files
+#include <sst/core/sst_config.h>
+
+#include "Child.h"
+
+
+using namespace SST;
+using namespace SST::cyclical;
+
+/***********************************************************************************/
+// Since the classes are brief, this file has the implementation for all four
+// basicSubComponentAPI subcomponents declared in basicSubComponent_subcomponent.h
+/***********************************************************************************/
+
+// basicSubComponentIncrement
+
+basicSubComponentIncrement::basicSubComponentIncrement(ComponentId_t id, Params& params) :
+    basicSubComponentAPI(id, params)
+{
+    amount = params.find<int>("amount",  1);
+}
+
+basicSubComponentIncrement::~basicSubComponentIncrement() { }
+
+int basicSubComponentIncrement::compute( int num )
+{
+    return num + amount;
+}
+
+std::string basicSubComponentIncrement::compute ( std::string comp )
+{
+    return "(" + comp + ")" + " + " + std::to_string(amount);
+}
+
+void basicSubComponentIncrement::serialize_order(SST::Core::Serialization::serializer& ser) {
+    SubComponent::serialize_order(ser);
+
+    SST_SER(amount);
+}

--- a/cyclical_reference/Child.cpp
+++ b/cyclical_reference/Child.cpp
@@ -31,8 +31,8 @@ using namespace SST::cyclical;
 
 // basicSubComponentIncrement
 
-basicSubComponentIncrement::basicSubComponentIncrement(ComponentId_t id, Params& params) :
-    basicSubComponentAPI(id, params)
+basicSubComponentIncrement::basicSubComponentIncrement(ComponentId_t id, Params& params, basicSubComponent_Component* parent, std::string link_name) 
+    : basicSubComponentAPI(id, params, parent, link_name), parent(parent), link_name(link_name)
 {
     amount = params.find<int>("amount",  1);
 }

--- a/cyclical_reference/Child.cpp
+++ b/cyclical_reference/Child.cpp
@@ -19,7 +19,9 @@
 #include <sst/core/sst_config.h>
 
 #include "Child.h"
+#include "Parent.h"
 
+#include <sst/core/interfaces/stringEvent.h>
 
 using namespace SST;
 using namespace SST::cyclical;
@@ -35,6 +37,9 @@ basicSubComponentIncrement::basicSubComponentIncrement(ComponentId_t id, Params&
     : basicSubComponentAPI(id, params, parent, link_name), parent(parent), link_name(link_name)
 {
     amount = params.find<int>("amount",  1);
+    link = configureLink(link_name, new Event::Handler2<basicSubComponentIncrement, &basicSubComponentIncrement::handleEvent>(this));
+        sst_assert(link, CALL_INFO, -1,
+                "Error: SubComponent %s has an incorrectly configured link on port '%s'\n", getName().c_str(), link_name.c_str());
 }
 
 basicSubComponentIncrement::~basicSubComponentIncrement() { }
@@ -53,4 +58,22 @@ void basicSubComponentIncrement::serialize_order(SST::Core::Serialization::seria
     SubComponent::serialize_order(ser);
 
     SST_SER(amount);
+}
+
+void basicSubComponentIncrement::handleEvent(SST::Event* ev) {
+    SST::Interfaces::StringEvent* payloadEv = 
+        dynamic_cast<SST::Interfaces::StringEvent*>(ev);
+
+    int received_value = std::stoi(payloadEv->getString());
+    std::cout << "Received event with value " << received_value << " on link " << link_name << std::endl;
+    parent->out->output("SubComponent %s received event with received_value %d. Remaining: %d\n", getName().c_str(), received_value, this->parent->value);
+   
+    parent->continuePassing(ev);
+    
+}
+
+void basicSubComponentIncrement::sendEvent(SST::Event* ev) {
+    std::cout << "Sending event with value " << dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString() << " on link " << link_name << std::endl;
+    link->send(ev);
+    std::cout << "Event sent with value " << dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString() << " on link " << link_name << std::endl;
 }

--- a/cyclical_reference/Child.h
+++ b/cyclical_reference/Child.h
@@ -48,6 +48,8 @@ public:
     // Serialization
     basicSubComponentAPI() {};
     ImplementVirtualSerializable(SST::cyclical::basicSubComponentAPI);
+
+    basicSubComponent_Component* parent;
 };
 
 /*****************************************************************************************************/
@@ -80,7 +82,7 @@ public:
 
     virtual void finish() override;
     // serialization
-    basicSubComponentIncrement() : basicSubComponentAPI() {};
+    basicSubComponentIncrement() : basicSubComponentAPI(), amount(0), parent(nullptr), link_name(""), link(nullptr) {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::cyclical::basicSubComponentIncrement);
 
@@ -89,6 +91,7 @@ private:
     basicSubComponent_Component * parent;
     std::string link_name;
     Link * link;
+
 };
 
 

--- a/cyclical_reference/Child.h
+++ b/cyclical_reference/Child.h
@@ -1,30 +1,13 @@
 #ifndef _BASIC_SUBCOMPONENT_SUBCOMPONENT_H
 #define _BASIC_SUBCOMPONENT_SUBCOMPONENT_H
 
-/*
- * This is an example of a simple subcomponent that can take a number and do a computation on it.
- * This file happens to have multiple classes declaring both the SubComponentAPI
- * as well as a few subcomponents that implement the API.
- *
- *  Classes:
- *      basicSubComponentAPI - inherits from SST::SubComponent. Defines the API for the compute units.
- *      basicSubComponentIncrement - inherits from basicSubComponentAPI. A compute unit that increments the input.
- *      basicSubComponentDecrement - inherits from basicSubComponentAPI. A compute unit that decrements the input.
- *      basicSubComponentMultiply - inherits from basicSubComponentAPI. A compute unit that multiplies the input.
- *      basicSubComponentDivide - inherits from basicSubComponentAPI. A compute unit that divides the input.
- *
- * See 'basicSubComponent_component.h' for more information on how the example simulation works
- */
-
 #include <sst/core/subcomponent.h>
 #include <sst/core/sst_config.h>
 
 namespace SST {
 namespace cyclical {
 
-/*****************************************************************************************************/
-
-class basicSubComponent_Component;
+class ParentComponent;
 
 
 class basicSubComponentAPI : public SST::SubComponent
@@ -33,69 +16,55 @@ public:
     /*
      * Register this API with SST so that SST can match subcomponent slots to subcomponents
      */
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::cyclical::basicSubComponentAPI, basicSubComponent_Component*, std::string)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::cyclical::basicSubComponentAPI, ParentComponent*, std::string)
 
-    basicSubComponentAPI(ComponentId_t id, Params& params, basicSubComponent_Component* parent, std::string link_name) : SubComponent(id) { }
+    basicSubComponentAPI(ComponentId_t id, Params& params, ParentComponent* parent, std::string link_name) : SubComponent(id) { }
     virtual ~basicSubComponentAPI() { }
 
-    // These are the two functions described in the comment above
-    virtual int compute( int num ) =0;
-    virtual std::string compute( std::string comp ) =0;
     virtual void handleEvent(SST::Event* ev) =0;
     virtual void sendEvent(SST::Event* ev) =0;
-
     virtual void finish() =0;
+
     // Serialization
     basicSubComponentAPI() {};
     ImplementVirtualSerializable(SST::cyclical::basicSubComponentAPI);
-
-    basicSubComponent_Component* parent;
 };
 
-/*****************************************************************************************************/
-
-/* SubComponent that does an 'increment' computation */
-class basicSubComponentIncrement : public basicSubComponentAPI {
+class basicSubComponent : public basicSubComponentAPI {
 public:
 
     // Register this subcomponent with SST and tell SST that it implements the 'basicSubComponentAPI' API
     SST_ELI_REGISTER_SUBCOMPONENT(
-            basicSubComponentIncrement,     // Class name
+            basicSubComponent,     // Class name
             "cyclical",         // Library name, the 'lib' in SST's lib.name format
-            "basicSubComponentIncrement",   // Name used to refer to this subcomponent, the 'name' in SST's lib.name format
+            "basicSubComponent",   // Name used to refer to this subcomponent, the 'name' in SST's lib.name format
             SST_ELI_ELEMENT_VERSION(1,0,0), // A version number
             "SubComponent that increments a value", // Description
             SST::cyclical::basicSubComponentAPI // Fully qualified name of the API this subcomponent implements
-                                                            // A subcomponent can implment an API from any library
             )
 
     // Other ELI macros as needed for parameters, ports, statistics, and subcomponent slots
     SST_ELI_DOCUMENT_PARAMS( { "amount", "Amount to increment by", "1" } )
 
-    basicSubComponentIncrement(ComponentId_t id, Params& params, basicSubComponent_Component* parent, std::string link_name);
-    ~basicSubComponentIncrement();
+    basicSubComponent(ComponentId_t id, Params& params, ParentComponent* parent, std::string link_name);
+    ~basicSubComponent();
 
-    int compute( int num) override;
-    std::string compute( std::string comp ) override;
     void handleEvent(SST::Event* ev) override;
     void sendEvent(SST::Event* ev) override;
-
     virtual void finish() override;
+
     // serialization
-    basicSubComponentIncrement() : basicSubComponentAPI(), amount(0), parent(nullptr), link_name(""), link(nullptr) {};
+    basicSubComponent() : basicSubComponentAPI(), amount(0), parent(nullptr), link_name(""), link(nullptr) {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
-    ImplementSerializable(SST::cyclical::basicSubComponentIncrement);
+    ImplementSerializable(SST::cyclical::basicSubComponent);
 
 private:
     int amount;
-    basicSubComponent_Component * parent;
+    ParentComponent * parent;
     std::string link_name;
     Link * link;
 
 };
-
-
-/*****************************************************************************************************/
 
 } } /* Namspaces */
 

--- a/cyclical_reference/Child.h
+++ b/cyclical_reference/Child.h
@@ -1,0 +1,108 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _BASIC_SUBCOMPONENT_SUBCOMPONENT_H
+#define _BASIC_SUBCOMPONENT_SUBCOMPONENT_H
+
+/*
+ * This is an example of a simple subcomponent that can take a number and do a computation on it.
+ * This file happens to have multiple classes declaring both the SubComponentAPI
+ * as well as a few subcomponents that implement the API.
+ *
+ *  Classes:
+ *      basicSubComponentAPI - inherits from SST::SubComponent. Defines the API for the compute units.
+ *      basicSubComponentIncrement - inherits from basicSubComponentAPI. A compute unit that increments the input.
+ *      basicSubComponentDecrement - inherits from basicSubComponentAPI. A compute unit that decrements the input.
+ *      basicSubComponentMultiply - inherits from basicSubComponentAPI. A compute unit that multiplies the input.
+ *      basicSubComponentDivide - inherits from basicSubComponentAPI. A compute unit that divides the input.
+ *
+ * See 'basicSubComponent_component.h' for more information on how the example simulation works
+ */
+
+#include <sst/core/subcomponent.h>
+#include <sst/core/sst_config.h>
+
+namespace SST {
+namespace cyclical {
+
+/*****************************************************************************************************/
+
+// SubComponent API for a SubComponent that has two functions:
+// 1) It does a specific computation on a number
+//      Ex. Given 5, if the computation is 'x4', the subcomponent should return 20
+// 2) Given a formula string, it will update the formula with the computation it does
+//      Ex. Given '3+2', if the computation is 'x4', the subcomponent should return '(3+2)x4'
+
+class basicSubComponentAPI : public SST::SubComponent
+{
+public:
+    /*
+     * Register this API with SST so that SST can match subcomponent slots to subcomponents
+     */
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::cyclical::basicSubComponentAPI)
+
+    basicSubComponentAPI(ComponentId_t id, Params& params) : SubComponent(id) { }
+    virtual ~basicSubComponentAPI() { }
+
+    // These are the two functions described in the comment above
+    virtual int compute( int num ) =0;
+    virtual std::string compute( std::string comp) =0;
+
+    // Serialization
+    basicSubComponentAPI() {};
+    ImplementVirtualSerializable(SST::cyclical::basicSubComponentAPI);
+};
+
+/*****************************************************************************************************/
+
+/* SubComponent that does an 'increment' computation */
+class basicSubComponentIncrement : public basicSubComponentAPI {
+public:
+
+    // Register this subcomponent with SST and tell SST that it implements the 'basicSubComponentAPI' API
+    SST_ELI_REGISTER_SUBCOMPONENT(
+            basicSubComponentIncrement,     // Class name
+            "cyclical",         // Library name, the 'lib' in SST's lib.name format
+            "basicSubComponentIncrement",   // Name used to refer to this subcomponent, the 'name' in SST's lib.name format
+            SST_ELI_ELEMENT_VERSION(1,0,0), // A version number
+            "SubComponent that increments a value", // Description
+            SST::cyclical::basicSubComponentAPI // Fully qualified name of the API this subcomponent implements
+                                                            // A subcomponent can implment an API from any library
+            )
+
+    // Other ELI macros as needed for parameters, ports, statistics, and subcomponent slots
+    SST_ELI_DOCUMENT_PARAMS( { "amount", "Amount to increment by", "1" } )
+
+    basicSubComponentIncrement(ComponentId_t id, Params& params);
+    ~basicSubComponentIncrement();
+
+    int compute( int num) override;
+    std::string compute( std::string comp ) override;
+
+    // serialization
+    basicSubComponentIncrement() : basicSubComponentAPI() {};
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::cyclical::basicSubComponentIncrement);
+
+private:
+    int amount;
+};
+
+
+/*****************************************************************************************************/
+
+} } /* Namspaces */
+
+#endif /* _BASIC_SUBCOMPONENT_SUBCOMPONENT_H */

--- a/cyclical_reference/Child.h
+++ b/cyclical_reference/Child.h
@@ -39,11 +39,8 @@ namespace cyclical {
 
 /*****************************************************************************************************/
 
-// SubComponent API for a SubComponent that has two functions:
-// 1) It does a specific computation on a number
-//      Ex. Given 5, if the computation is 'x4', the subcomponent should return 20
-// 2) Given a formula string, it will update the formula with the computation it does
-//      Ex. Given '3+2', if the computation is 'x4', the subcomponent should return '(3+2)x4'
+class basicSubComponent_Component;
+
 
 class basicSubComponentAPI : public SST::SubComponent
 {
@@ -51,9 +48,9 @@ public:
     /*
      * Register this API with SST so that SST can match subcomponent slots to subcomponents
      */
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::cyclical::basicSubComponentAPI)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::cyclical::basicSubComponentAPI, basicSubComponent_Component*, std::string)
 
-    basicSubComponentAPI(ComponentId_t id, Params& params) : SubComponent(id) { }
+    basicSubComponentAPI(ComponentId_t id, Params& params, basicSubComponent_Component* parent, std::string link_name) : SubComponent(id) { }
     virtual ~basicSubComponentAPI() { }
 
     // These are the two functions described in the comment above
@@ -85,7 +82,7 @@ public:
     // Other ELI macros as needed for parameters, ports, statistics, and subcomponent slots
     SST_ELI_DOCUMENT_PARAMS( { "amount", "Amount to increment by", "1" } )
 
-    basicSubComponentIncrement(ComponentId_t id, Params& params);
+    basicSubComponentIncrement(ComponentId_t id, Params& params, basicSubComponent_Component* parent, std::string link_name);
     ~basicSubComponentIncrement();
 
     int compute( int num) override;
@@ -98,6 +95,9 @@ public:
 
 private:
     int amount;
+    basicSubComponent_Component * parent;
+    std::string link_name;
+    Link * link;
 };
 
 

--- a/cyclical_reference/Child.h
+++ b/cyclical_reference/Child.h
@@ -1,18 +1,3 @@
-// Copyright 2009-2025 NTESS. Under the terms
-// of Contract DE-NA0003525 with NTESS, the U.S.
-// Government retains certain rights in this software.
-//
-// Copyright (c) 2009-2025, NTESS
-// All rights reserved.
-//
-// Portions are copyright of other developers:
-// See the file CONTRIBUTORS.TXT in the top level directory
-// of the distribution for more information.
-//
-// This file is part of the SST software package. For license
-// information, see the LICENSE file in the top level directory of the
-// distribution.
-
 #ifndef _BASIC_SUBCOMPONENT_SUBCOMPONENT_H
 #define _BASIC_SUBCOMPONENT_SUBCOMPONENT_H
 
@@ -55,8 +40,9 @@ public:
 
     // These are the two functions described in the comment above
     virtual int compute( int num ) =0;
-    virtual std::string compute( std::string comp) =0;
-
+    virtual std::string compute( std::string comp ) =0;
+    virtual void handleEvent(SST::Event* ev) =0;
+    virtual void sendEvent(SST::Event* ev) =0;
     // Serialization
     basicSubComponentAPI() {};
     ImplementVirtualSerializable(SST::cyclical::basicSubComponentAPI);
@@ -87,7 +73,8 @@ public:
 
     int compute( int num) override;
     std::string compute( std::string comp ) override;
-
+    void handleEvent(SST::Event* ev) override;
+    void sendEvent(SST::Event* ev) override;
     // serialization
     basicSubComponentIncrement() : basicSubComponentAPI() {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;

--- a/cyclical_reference/Child.h
+++ b/cyclical_reference/Child.h
@@ -43,6 +43,8 @@ public:
     virtual std::string compute( std::string comp ) =0;
     virtual void handleEvent(SST::Event* ev) =0;
     virtual void sendEvent(SST::Event* ev) =0;
+
+    virtual void finish() =0;
     // Serialization
     basicSubComponentAPI() {};
     ImplementVirtualSerializable(SST::cyclical::basicSubComponentAPI);
@@ -75,6 +77,8 @@ public:
     std::string compute( std::string comp ) override;
     void handleEvent(SST::Event* ev) override;
     void sendEvent(SST::Event* ev) override;
+
+    virtual void finish() override;
     // serialization
     basicSubComponentIncrement() : basicSubComponentAPI() {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;

--- a/cyclical_reference/Makefile
+++ b/cyclical_reference/Makefile
@@ -1,0 +1,25 @@
+CXX=$(shell sst-config --CXX)
+CXXFLAGS=$(shell sst-config --ELEMENT_CXXFLAGS) -g
+LDFLAGS=$(shell sst-config --ELEMENT_LDFLAGS)
+PARAMS=-DENABLE_SSTCHECKPOINT
+#PARAMS="-DENABLE_SSTDBG"
+
+SRCS=Parent.cpp Child.cpp
+
+all: libcyclical.so install
+
+libcyclical.so: $(SRCS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(PARAMS) -o $@ $^
+
+install:
+	sst-register cyclical cyclical_LIBDIR=$(CURDIR)
+
+dataclean:
+	 rm -rf *_dir *.out
+	 rm -rf rank_*_thread_*
+
+clean:
+	rm -rf tests/graphs libcyclical.so
+	sst-register -u cyclical
+	rm -r *.json *.tmp *.time *.out
+

--- a/cyclical_reference/Parent.cpp
+++ b/cyclical_reference/Parent.cpp
@@ -51,8 +51,10 @@ basicSubComponent_Component::basicSubComponent_Component(ComponentId_t id, Param
     /****** Load a SubComponent in two steps ******/
 
     // 1. Check with the input configuration to see if the user put a subcomponent in our subcomponent slot
-    computeUnit = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
-                "computeUnit", 0, ComponentInfo::SHARE_NONE, params);
+    leftChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
+                "children", 0, ComponentInfo::SHARE_NONE, params, this, "left");
+    rightChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
+                "children", 1, ComponentInfo::SHARE_NONE, params, this, "right");
 
     /****** SubComponent loaded, almost done with construction ******/
 
@@ -130,5 +132,6 @@ void basicSubComponent_Component::serialize_order(SST::Core::Serialization::seri
     SST_SER(leftLink);
     SST_SER(rightLink);
 
-    SST_SER(computeUnit);
+    SST_SER(leftChild);
+    SST_SER(rightChild);
 }

--- a/cyclical_reference/Parent.cpp
+++ b/cyclical_reference/Parent.cpp
@@ -24,115 +24,67 @@
 using namespace SST;
 using namespace SST::cyclical;
 
-/*
- * During construction this components parses its parameter, configures its links, and loads its compute unit subcomponent
- */
-basicSubComponent_Component::basicSubComponent_Component(ComponentId_t id, Params& params) : Component(id) {
+ParentComponent::ParentComponent(ComponentId_t id, Params& params) : Component(id) {
 
-    // SST Output Object
     out = new Output("", 1, 0, Output::STDOUT);
 
-    // Get the parameter, check if it was found or not and if not, return an error
     bool found;
     value = params.find<int>("value", 0, found);
     sst_assert(found, CALL_INFO, -1,
-            "Error: The parameter 'value' is a required parameter and was not found in the input configuration\n");
+            "Error: The parameter 'value' is a required parameter and was not found "
+            "in the input configuration\n");
     
-    // Configure our links to call our event handler when an event arrives
-    //leftLink = configureLink("left", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
-    //rightLink = configureLink("right", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
-
-
-    /****** Load a SubComponent in two steps ******/
-    std::cout << "Loading subcomponents for component " << getName() << std::endl;
-    // 1. Check with the input configuration to see if the user put a subcomponent in our subcomponent slot
-    leftChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
+    leftChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponent",
                 "left_slot", 0, ComponentInfo::SHARE_PORTS, params, this, "left");
-    rightChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
+    rightChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponent",
                 "right_slot", 0, ComponentInfo::SHARE_PORTS, params, this, "right");
-    std::cout << "Finished loading subcomponents for component " << getName() << std::endl;
-    /****** SubComponent loaded, almost done with construction ******/
 
-    // Tell the simulation not to end until we're ready
     registerAsPrimaryComponent();
     primaryComponentDoNotEndSim();
 }
 
 
-/*
- * Destructor, clean up our output
- * We should not clean up our subcomponent - SST will do that
- */
-basicSubComponent_Component::~basicSubComponent_Component()
+ParentComponent::~ParentComponent()
 {
     delete out;
 }
 
-
-/*
- * Setup function to send our event in preparation for simulation
- * Because the simulation has no clocks and SST will exit if no clocks and no events exist in the system,
- * we need to begin the simulation with an event.
- *
- * This function is called by SST on each component just prior to simulation start
- * It is *not* called on subcomponents automatically so we should manually call it on subcomponents that need it
- * Ours don't so we'll skip that step
- */
-void basicSubComponent_Component::setup()
+void ParentComponent::setup()
 { 
     // Create the event we'll send
     SST::Event* event = new SST::Interfaces::StringEvent("0");
 
-    // Send our event
+    // Send our event through the left child.
     leftChild->sendEvent(event);
 }
 
-void basicSubComponent_Component::finish() {
-    out->output("Component %s is finishing. Final value: %d\n", getName().c_str(), this->value);
+void ParentComponent::finish() {
+    out->output("Component %s is finishing. Final value: %d\n",
+         getName().c_str(), this->value);
     leftChild->finish();
     rightChild->finish();
 }
 
-/*
- * Event handling
- * If we get the event we sent, print the result and tell SST that we're OK if the simulation ends
- * If we get an event from someone else, pass it to our compute unit, update the event, and forward it to the left
- */
-
-void basicSubComponent_Component::handleEvent(SST::Event* ev)
-{
-   out->output("Component %s received an event\n", getName().c_str());
-}
-
-void basicSubComponent_Component::continuePassing(SST::Event* ev) {
+void ParentComponent::computeAndSend(SST::Event* ev) {
     int event_value = std::stoi(dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString());
 
-    std::cout << "In continuePassing, out pointer is: " << out << std::endl;
-
-    out->output("Component %s is continuing to pass the event. Remaining value: %d. Event value: %d\n", getName().c_str(), this->value, event_value);
+    out->output("Component %s is continuing to pass the event."
+        "Remaining value: %d. Event value: %d\n", getName().c_str(), 
+        this->value, event_value);
 
     this->value -= event_value;
 
     if (this->value <= 0) {
-        registerReady();
+        out->output("Component %s is ready to end simulation\n", getName().c_str());
+        primaryComponentOKToEndSim();
     }
     leftChild->sendEvent(ev);
 }
 
-void basicSubComponent_Component::registerReady() {
-    out->output("Component %s is ready to end simulation\n", getName().c_str());
-    primaryComponentOKToEndSim();
-}
+ParentComponent::ParentComponent() : Component() {}
 
-/*
- * Default constructor
-*/
-basicSubComponent_Component::basicSubComponent_Component() : Component() {}
 
-/*
- * Serialization function
-*/
-void basicSubComponent_Component::serialize_order(SST::Core::Serialization::serializer& ser) {
+void ParentComponent::serialize_order(SST::Core::Serialization::serializer& ser) {
     Component::serialize_order(ser);
 
     SST_SER(out);

--- a/cyclical_reference/Parent.cpp
+++ b/cyclical_reference/Parent.cpp
@@ -37,25 +37,20 @@ basicSubComponent_Component::basicSubComponent_Component(ComponentId_t id, Param
     value = params.find<int>("value", 0, found);
     sst_assert(found, CALL_INFO, -1,
             "Error: The parameter 'value' is a required parameter and was not found in the input configuration\n");
-
+    
     // Configure our links to call our event handler when an event arrives
-    leftLink = configureLink("left", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
-    rightLink = configureLink("right", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
+    //leftLink = configureLink("left", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
+    //rightLink = configureLink("right", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
 
-    // Check that the links were configured correctly
-    sst_assert(leftLink, CALL_INFO, -1,
-            "Error: Component %s has an incorrectly configured link on port 'left'\n", getName().c_str());
-    sst_assert(rightLink, CALL_INFO, -1,
-            "Error: Component %s has an incorrectly configured link on port 'right'\n", getName().c_str());
 
     /****** Load a SubComponent in two steps ******/
-
+    std::cout << "Loading subcomponents for component " << getName() << std::endl;
     // 1. Check with the input configuration to see if the user put a subcomponent in our subcomponent slot
     leftChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
-                "children", 0, ComponentInfo::SHARE_NONE, params, this, "left");
+                "left_slot", 0, ComponentInfo::SHARE_PORTS, params, this, "left");
     rightChild = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
-                "children", 1, ComponentInfo::SHARE_NONE, params, this, "right");
-
+                "right_slot", 0, ComponentInfo::SHARE_PORTS, params, this, "right");
+    std::cout << "Finished loading subcomponents for component " << getName() << std::endl;
     /****** SubComponent loaded, almost done with construction ******/
 
     // Tell the simulation not to end until we're ready
@@ -89,7 +84,7 @@ void basicSubComponent_Component::setup()
     SST::Event* event = new SST::Interfaces::StringEvent("0");
 
     // Send our event
-    leftLink->send(event);
+    leftChild->sendEvent(event);
 }
 
 /*
@@ -100,19 +95,21 @@ void basicSubComponent_Component::setup()
 
 void basicSubComponent_Component::handleEvent(SST::Event* ev)
 {
-    SST::Interfaces::StringEvent* payloadEv = 
-        dynamic_cast<SST::Interfaces::StringEvent*>(ev);
+   out->output("Component %s received an event\n", getName().c_str());
+}
 
-    int received_value = std::stoi(payloadEv->getString());
-    out->output("Component %s received event with received_value %d. Remaining: %d\n", getName().c_str(), received_value, this->value);
-    leftLink->send(ev);
+void basicSubComponent_Component::continuePassing(SST::Event* ev) {
+    std::cout << "Component " << getName() << " is passing the event along. Remaining value: " << this->value << std::endl;
     this->value -= 1;
     if (this->value <= 0) {
-        out->output("Component %s is ready to end simulation\n", getName().c_str());
-        primaryComponentOKToEndSim();
+        registerReady();
     }
+    leftChild->sendEvent(ev);
+}
 
-    
+void basicSubComponent_Component::registerReady() {
+    out->output("Component %s is ready to end simulation\n", getName().c_str());
+    primaryComponentOKToEndSim();
 }
 
 /*

--- a/cyclical_reference/Parent.cpp
+++ b/cyclical_reference/Parent.cpp
@@ -1,0 +1,134 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+// This include is ***REQUIRED***
+// for ALL SST implementation files
+#include "sst/core/sst_config.h"
+
+#include "Child.h"
+#include "Parent.h"
+#include <sst/core/interfaces/stringEvent.h>
+using namespace SST;
+using namespace SST::cyclical;
+
+/*
+ * During construction this components parses its parameter, configures its links, and loads its compute unit subcomponent
+ */
+basicSubComponent_Component::basicSubComponent_Component(ComponentId_t id, Params& params) : Component(id) {
+
+    // SST Output Object
+    out = new Output("", 1, 0, Output::STDOUT);
+
+    // Get the parameter, check if it was found or not and if not, return an error
+    bool found;
+    value = params.find<int>("value", 0, found);
+    sst_assert(found, CALL_INFO, -1,
+            "Error: The parameter 'value' is a required parameter and was not found in the input configuration\n");
+
+    // Configure our links to call our event handler when an event arrives
+    leftLink = configureLink("left", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
+    rightLink = configureLink("right", new Event::Handler2<basicSubComponent_Component, &basicSubComponent_Component::handleEvent>(this));
+
+    // Check that the links were configured correctly
+    sst_assert(leftLink, CALL_INFO, -1,
+            "Error: Component %s has an incorrectly configured link on port 'left'\n", getName().c_str());
+    sst_assert(rightLink, CALL_INFO, -1,
+            "Error: Component %s has an incorrectly configured link on port 'right'\n", getName().c_str());
+
+    /****** Load a SubComponent in two steps ******/
+
+    // 1. Check with the input configuration to see if the user put a subcomponent in our subcomponent slot
+    computeUnit = loadAnonymousSubComponent<basicSubComponentAPI>("cyclical.basicSubComponentIncrement",
+                "computeUnit", 0, ComponentInfo::SHARE_NONE, params);
+
+    /****** SubComponent loaded, almost done with construction ******/
+
+    // Tell the simulation not to end until we're ready
+    registerAsPrimaryComponent();
+    primaryComponentDoNotEndSim();
+}
+
+
+/*
+ * Destructor, clean up our output
+ * We should not clean up our subcomponent - SST will do that
+ */
+basicSubComponent_Component::~basicSubComponent_Component()
+{
+    delete out;
+}
+
+
+/*
+ * Setup function to send our event in preparation for simulation
+ * Because the simulation has no clocks and SST will exit if no clocks and no events exist in the system,
+ * we need to begin the simulation with an event.
+ *
+ * This function is called by SST on each component just prior to simulation start
+ * It is *not* called on subcomponents automatically so we should manually call it on subcomponents that need it
+ * Ours don't so we'll skip that step
+ */
+void basicSubComponent_Component::setup()
+{ 
+    // Create the event we'll send
+    SST::Event* event = new SST::Interfaces::StringEvent("0");
+
+    // Send our event
+    leftLink->send(event);
+}
+
+/*
+ * Event handling
+ * If we get the event we sent, print the result and tell SST that we're OK if the simulation ends
+ * If we get an event from someone else, pass it to our compute unit, update the event, and forward it to the left
+ */
+
+void basicSubComponent_Component::handleEvent(SST::Event* ev)
+{
+    SST::Interfaces::StringEvent* payloadEv = 
+        dynamic_cast<SST::Interfaces::StringEvent*>(ev);
+
+    int received_value = std::stoi(payloadEv->getString());
+    out->output("Component %s received event with received_value %d. Remaining: %d\n", getName().c_str(), received_value, this->value);
+    leftLink->send(ev);
+    this->value -= 1;
+    if (this->value <= 0) {
+        out->output("Component %s is ready to end simulation\n", getName().c_str());
+        primaryComponentOKToEndSim();
+    }
+
+    
+}
+
+/*
+ * Default constructor
+*/
+basicSubComponent_Component::basicSubComponent_Component() : Component() {}
+
+/*
+ * Serialization function
+*/
+void basicSubComponent_Component::serialize_order(SST::Core::Serialization::serializer& ser) {
+    Component::serialize_order(ser);
+
+    SST_SER(out);
+    SST_SER(value);
+
+    SST_SER(leftLink);
+    SST_SER(rightLink);
+
+    SST_SER(computeUnit);
+}

--- a/cyclical_reference/Parent.cpp
+++ b/cyclical_reference/Parent.cpp
@@ -87,6 +87,12 @@ void basicSubComponent_Component::setup()
     leftChild->sendEvent(event);
 }
 
+void basicSubComponent_Component::finish() {
+    out->output("Component %s is finishing. Final value: %d\n", getName().c_str(), this->value);
+    leftChild->finish();
+    rightChild->finish();
+}
+
 /*
  * Event handling
  * If we get the event we sent, print the result and tell SST that we're OK if the simulation ends
@@ -99,8 +105,12 @@ void basicSubComponent_Component::handleEvent(SST::Event* ev)
 }
 
 void basicSubComponent_Component::continuePassing(SST::Event* ev) {
-    std::cout << "Component " << getName() << " is passing the event along. Remaining value: " << this->value << std::endl;
-    this->value -= 1;
+    int event_value = std::stoi(dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString());
+
+    out->output("Component %s is continuing to pass the event. Remaining value: %d. Event value: %d\n", getName().c_str(), this->value, event_value);
+
+    this->value -= event_value;
+
     if (this->value <= 0) {
         registerReady();
     }

--- a/cyclical_reference/Parent.cpp
+++ b/cyclical_reference/Parent.cpp
@@ -107,6 +107,8 @@ void basicSubComponent_Component::handleEvent(SST::Event* ev)
 void basicSubComponent_Component::continuePassing(SST::Event* ev) {
     int event_value = std::stoi(dynamic_cast<SST::Interfaces::StringEvent*>(ev)->getString());
 
+    std::cout << "In continuePassing, out pointer is: " << out << std::endl;
+
     out->output("Component %s is continuing to pass the event. Remaining value: %d. Event value: %d\n", getName().c_str(), this->value, event_value);
 
     this->value -= event_value;
@@ -135,9 +137,6 @@ void basicSubComponent_Component::serialize_order(SST::Core::Serialization::seri
 
     SST_SER(out);
     SST_SER(value);
-
-    SST_SER(leftLink);
-    SST_SER(rightLink);
 
     SST_SER(leftChild);
     SST_SER(rightChild);

--- a/cyclical_reference/Parent.h
+++ b/cyclical_reference/Parent.h
@@ -85,7 +85,7 @@ public:
     // Parameter 2: Description of the purpose/use/etc. of the slot
     // Parameter 3: The API the subcomponent slot will use
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
-            { "compute_unit",
+            { "children",
             "The compute unit that this component will use to operate on events",
             "SST::cyclical::basicSubComponentAPI" }
             )
@@ -118,7 +118,8 @@ private:
     SST::Link* rightLink;
 
     // SubComponent: Our compute unit
-    SST::cyclical::basicSubComponentAPI* computeUnit;
+    SST::cyclical::basicSubComponentAPI* leftChild;
+    SST::cyclical::basicSubComponentAPI* rightChild;
 
 };
 

--- a/cyclical_reference/Parent.h
+++ b/cyclical_reference/Parent.h
@@ -1,0 +1,128 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _BASICSUBCOMPONENT_COMPONENT_H
+#define _BASICSUBCOMPONENT_COMPONENT_H
+
+/*
+ * This example demonstrates the use of subcomponents.
+ *
+ * Concepts covered:
+ *  - ELI macros for defining subcomponent slots
+ *  - Loading a user vs anonymous subcomponent
+ *  - Declaring a subcomponent api
+ *  - Defining subcomponents
+ *
+ *
+ *  This file defines a Component with a SubComponent slot.
+ *
+ *
+ *  The simulation works this way:
+ *      - The components are connected in a ring
+ *      - Each component has a "compute" SubComponent that controls what kind of computation it does
+ *      - Each component sends one message around the ring which contains an integer and a string describing the computation
+ *      - When a component receives a message, it has its "compute" SubComponent operate on the integer
+ *          and then forwards the integer to its neighbor. It also updates the string to describe what it did.
+ *      - When a component receives the message it sent, it prints the string and the result
+ *      - Whan all components have received the messages they sent, the simulation ends
+ */
+
+#include <sst/core/component.h>
+#include <sst/core/link.h>
+
+// Include file for the SubComponent API we'll use
+#include "Child.h"
+
+namespace SST {
+namespace cyclical {
+
+
+class basicSubComponent_Component : public SST::Component
+{
+public:
+
+/*
+ *  SST Registration macros register Components with the SST Core and
+ *  document their parameters, ports, etc.
+ *  SST_ELI_REGISTER_COMPONENT is required, the documentation macros
+ *  are only required if relevant
+ */
+    // REGISTER THIS COMPONENT INTO THE ELEMENT LIBRARY
+    SST_ELI_REGISTER_COMPONENT(
+        basicSubComponent_Component,        // Component class
+        "cyclical",             // Component library (for Python/library lookup)
+        "basicSubComponent_comp",           // Component name (for Python/library lookup)
+        SST_ELI_ELEMENT_VERSION(1,0,0),     // Version of the component (not related to SST version)
+        "Basic: Using subcomponents",       // Description
+        COMPONENT_CATEGORY_UNCATEGORIZED    // Category
+    )
+
+    SST_ELI_DOCUMENT_PARAMS(
+        { "value",      "Integer starting value for this component", NULL }
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+            {"left", "Link to left neighbor"},
+            {"right", "Link to right neighbor"}
+    )
+
+    SST_ELI_DOCUMENT_STATISTICS()
+
+    // This Macro informs SST that this Component can load a SubComponent.
+    // Parameter 1: Name of the location for the subcomponent
+    // Parameter 2: Description of the purpose/use/etc. of the slot
+    // Parameter 3: The API the subcomponent slot will use
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+            { "compute_unit",
+            "The compute unit that this component will use to operate on events",
+            "SST::cyclical::basicSubComponentAPI" }
+            )
+
+    // Constructor & destructor
+    basicSubComponent_Component(SST::ComponentId_t id, SST::Params& params);
+    ~basicSubComponent_Component();
+
+    // We will use the 'setup' function from the simulation lifecycle to send our event
+    virtual void setup() override;
+
+    // Event handler, called when an event is received on either link
+    void handleEvent(SST::Event* ev);
+
+// Serialization
+    basicSubComponent_Component();
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::cyclical::basicSubComponent_Component)
+
+private:
+
+    // SST Output object, for printing, error messages, etc.
+    SST::Output* out;
+
+    // Input parameter: the value this component will send in its event
+    int value;
+
+    // Links
+    SST::Link* leftLink;
+    SST::Link* rightLink;
+
+    // SubComponent: Our compute unit
+    SST::cyclical::basicSubComponentAPI* computeUnit;
+
+};
+
+} // namespace cyclical
+} // namespace SST
+
+#endif /* _BASICSUBCOMPONENT_COMPONENT_H */

--- a/cyclical_reference/Parent.h
+++ b/cyclical_reference/Parent.h
@@ -85,7 +85,10 @@ public:
     // Parameter 2: Description of the purpose/use/etc. of the slot
     // Parameter 3: The API the subcomponent slot will use
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
-            { "children",
+            { "left_slot",
+            "The compute unit that this component will use to operate on events",
+            "SST::cyclical::basicSubComponentAPI" },
+            { "right_slot",
             "The compute unit that this component will use to operate on events",
             "SST::cyclical::basicSubComponentAPI" }
             )
@@ -100,13 +103,15 @@ public:
     // Event handler, called when an event is received on either link
     void handleEvent(SST::Event* ev);
 
+    void registerReady();
+    void continuePassing(SST::Event* ev);
+
 // Serialization
     basicSubComponent_Component();
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::cyclical::basicSubComponent_Component)
 
-private:
-
+public:
     // SST Output object, for printing, error messages, etc.
     SST::Output* out;
 

--- a/cyclical_reference/Parent.h
+++ b/cyclical_reference/Parent.h
@@ -13,8 +13,8 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#ifndef _BASICSUBCOMPONENT_COMPONENT_H
-#define _BASICSUBCOMPONENT_COMPONENT_H
+#ifndef _ParentComponent_H
+#define _ParentComponent_H
 
 /*
  * This example demonstrates the use of subcomponents.
@@ -49,19 +49,12 @@ namespace SST {
 namespace cyclical {
 
 
-class basicSubComponent_Component : public SST::Component
+class ParentComponent : public SST::Component
 {
 public:
 
-/*
- *  SST Registration macros register Components with the SST Core and
- *  document their parameters, ports, etc.
- *  SST_ELI_REGISTER_COMPONENT is required, the documentation macros
- *  are only required if relevant
- */
-    // REGISTER THIS COMPONENT INTO THE ELEMENT LIBRARY
     SST_ELI_REGISTER_COMPONENT(
-        basicSubComponent_Component,        // Component class
+        ParentComponent,        // Component class
         "cyclical",             // Component library (for Python/library lookup)
         "basicSubComponent_comp",           // Component name (for Python/library lookup)
         SST_ELI_ELEMENT_VERSION(1,0,0),     // Version of the component (not related to SST version)
@@ -70,7 +63,7 @@ public:
     )
 
     SST_ELI_DOCUMENT_PARAMS(
-        { "value",      "Integer starting value for this component", NULL }
+        { "value",      "Integer starting value for this component. Counts down throughout the simulation.", NULL }
     )
 
     SST_ELI_DOCUMENT_PORTS(
@@ -93,34 +86,30 @@ public:
             "SST::cyclical::basicSubComponentAPI" }
             )
 
-    // Constructor & destructor
-    basicSubComponent_Component(SST::ComponentId_t id, SST::Params& params);
-    ~basicSubComponent_Component();
+    ParentComponent(SST::ComponentId_t id, SST::Params& params);
+    ~ParentComponent();
 
-    // We will use the 'setup' function from the simulation lifecycle to send our event
     virtual void setup() override;
 
     virtual void finish() override;
 
-    // Event handler, called when an event is received on either link
-    void handleEvent(SST::Event* ev);
+    /*
+        Decreases our counter field by the value of the event and passes 
+        the event along to the next component. Importantly, this does not 
+        call send itself. It passes that on to one of the components.
+    */
+    void computeAndSend(SST::Event* ev);
 
-    void registerReady();
-    void continuePassing(SST::Event* ev);
 
-// Serialization
-    basicSubComponent_Component();
+    ParentComponent();
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
-    ImplementSerializable(SST::cyclical::basicSubComponent_Component)
+    ImplementSerializable(SST::cyclical::ParentComponent)
 
 public:
-    // SST Output object, for printing, error messages, etc.
     SST::Output* out;
 
-    // Input parameter: the value this component will send in its event
     int value;
 
-    // SubComponent: Our compute unit
     SST::cyclical::basicSubComponentAPI* leftChild;
     SST::cyclical::basicSubComponentAPI* rightChild;
 
@@ -129,4 +118,4 @@ public:
 } // namespace cyclical
 } // namespace SST
 
-#endif /* _BASICSUBCOMPONENT_COMPONENT_H */
+#endif /* _ParentComponent_H */

--- a/cyclical_reference/Parent.h
+++ b/cyclical_reference/Parent.h
@@ -100,6 +100,8 @@ public:
     // We will use the 'setup' function from the simulation lifecycle to send our event
     virtual void setup() override;
 
+    virtual void finish() override;
+    
     // Event handler, called when an event is received on either link
     void handleEvent(SST::Event* ev);
 

--- a/cyclical_reference/Parent.h
+++ b/cyclical_reference/Parent.h
@@ -101,7 +101,7 @@ public:
     virtual void setup() override;
 
     virtual void finish() override;
-    
+
     // Event handler, called when an event is received on either link
     void handleEvent(SST::Event* ev);
 
@@ -119,10 +119,6 @@ public:
 
     // Input parameter: the value this component will send in its event
     int value;
-
-    // Links
-    SST::Link* leftLink;
-    SST::Link* rightLink;
 
     // SubComponent: Our compute unit
     SST::cyclical::basicSubComponentAPI* leftChild;

--- a/cyclical_reference/README.md
+++ b/cyclical_reference/README.md
@@ -1,0 +1,82 @@
+# Cyclical Component/Subcomponent Checkpoint Test
+
+This example demonstrates that SST checkpoint/restart remains correct even when there are cyclical references between components and subcomponents. This functions as a simple proof of concept for the main concerns around making the Merlin element library checkpointable. 
+
+## What this test demonstrates
+
+The key property being tested is a bidirectional reference between a component and its subcomponents:
+
+- `ParentComponent` holds pointers to two subcomponents (`leftChild`, `rightChild`).
+- Each `basicSubComponent` holds a pointer back to its owning `ParentComponent`.
+
+That creates a cycle in the object graph:
+
+`ParentComponent -> basicSubComponent -> ParentComponent`
+
+Both sides of this relationship are serialized, then restored from checkpoint.
+
+## Files
+
+- `Parent.h` / `Parent.cpp`
+  - Defines `ParentComponent`.
+  - Loads two anonymous subcomponents via `loadAnonymousSubComponent`.
+  - Serializes parent-side state and child pointers in `serialize_order`.
+- `Child.h` / `Child.cpp`
+  - Defines the subcomponent API (`basicSubComponentAPI`) and implementation (`basicSubComponent`).
+  - Subcomponent stores a back-pointer to `ParentComponent` and uses it in `handleEvent`.
+  - Serializes subcomponent state including the parent pointer.
+- `cyclical.py`
+  - Builds a 10-component ring topology.
+  - Uses deterministic random initialization (`random.seed(42)`) so runs are reproducible.
+
+## Build
+
+From this directory:
+
+```bash
+make
+```
+
+This produces `libcyclical.so` and registers the element library.
+
+## Run: baseline with checkpoint creation
+
+```bash
+sst --checkpoint-sim-period=100ns --checkpoint-prefix=checkpoint cyclical.py > original_output.txt
+```
+
+This creates a checkpoint manifest at:
+
+`checkpoint/checkpoint_1_100000/checkpoint_1_100000.sstcpt`
+
+## Run: restart from checkpoint
+
+```bash
+sst checkpoint/checkpoint_1_100000/checkpoint_1_100000.sstcpt > restored_output.txt
+```
+
+SST auto-detects `.sstcpt` as restart input.
+
+## How to validate correctness
+
+A strict byte-for-byte diff is not the best check because:
+
+- Parent pointer addresses naturally differ between processes/runs.
+- Finalization print order may differ while representing the same final state.
+
+Use semantic checks instead:
+
+```bash
+# Both runs should end at the same simulated time
+grep "Simulation is complete" original_output.txt restored_output.txt
+
+# Compare final component/subcomponent states independent of line order
+grep -E "is finishing\. Final value|is finishing\. Final amount|Simulation is complete" original_output.txt | sort > /tmp/orig.summary
+grep -E "is finishing\. Final value|is finishing\. Final amount|Simulation is complete" restored_output.txt | sort > /tmp/rest.summary
+diff -u /tmp/orig.summary /tmp/rest.summary
+```
+
+Expected outcome:
+
+- Both runs report `Simulation is complete, simulated time: 170 ns`.
+- Final component values and subcomponent amounts match between baseline and restart.

--- a/cyclical_reference/cyclical.py
+++ b/cyclical_reference/cyclical.py
@@ -1,0 +1,20 @@
+import sst
+
+num_components = 10 
+
+links = [] # List of link handlers
+for x in range(num_components):
+    link = sst.Link("link_" + str(x))
+    links.append(link)
+
+
+### Create the components and link
+for x in range(num_components):
+    component = sst.Component("component_" + str(x), "cyclical.basicSubComponent_comp")
+
+    # Have all components start with some number between 0 and 5
+    component.addParam("value", (x + 1) % 6)
+
+    # Connect the components to each other in a ring
+    component.addLink(links[x-1], "left", "10ns")
+    component.addLink(links[x], "right", "10ns")

--- a/cyclical_reference/cyclical.py
+++ b/cyclical_reference/cyclical.py
@@ -1,6 +1,9 @@
 import sst
 
+import random
 num_components = 10 
+
+random.seed(42) # Set the seed for reproducibility
 
 links = [] # List of link handlers
 for x in range(num_components):
@@ -12,8 +15,8 @@ for x in range(num_components):
 for x in range(num_components):
     component = sst.Component("component_" + str(x), "cyclical.basicSubComponent_comp")
 
-    # Have all components start with some number between 0 and 5
-    component.addParam("value", (x + 1) % 6)
+    # Have all components start with a large number
+    component.addParam("value", random.randint(1000, 10000))
 
     # Connect the components to each other in a ring
     component.addLink(links[x-1], "left", "10ns")

--- a/cyclical_reference/cyclical.py
+++ b/cyclical_reference/cyclical.py
@@ -16,7 +16,7 @@ for x in range(num_components):
     component = sst.Component("component_" + str(x), "cyclical.basicSubComponent_comp")
 
     # Have all components start with a large number
-    component.addParam("value", random.randint(1000, 10000))
+    component.addParam("value", random.randint(100, 1000))
 
     # Connect the components to each other in a ring
     component.addLink(links[x-1], "left", "10ns")


### PR DESCRIPTION
This PR adds a small proof of concept simulation for cyclical references between components and their subcomponents. This is to demonstrate that the cyclical references within the Merlin element library do not require changes to the serialization approach. The readme includes instructions to build, run, and verify that checkpoint-restore does not alter the final simulation state. 