### PR TITLE
Fix makefile clean target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ hpcstruct*
 *.so
 *~
 *.so.dSYM
+*.sstcpt
+*.bin

--- a/gameoflife/Makefile
+++ b/gameoflife/Makefile
@@ -18,4 +18,4 @@ install:
 clean:
 	rm -rf libgol.so
 	sst-register -u libgol
-	rm *.json *.tmp *.time *.out
+	rm -f *.json *.tmp *.time *.out

--- a/phold/Makefile
+++ b/phold/Makefile
@@ -21,5 +21,5 @@ dataclean:
 clean:
 	rm -rf tests/graphs libphold.so
 	sst-register -u phold
-	rm -r *.json *.tmp *.time *.out
+	rm -rf *.json *.tmp *.time *.out
 

--- a/pingpong/Makefile
+++ b/pingpong/Makefile
@@ -19,4 +19,4 @@ install:
 clean:
 	rm -rf tests/graphs libpingpong.so
 	sst-register -u pingpong
-	rm *.json *.tmp *.time *.out
+	rm -f *.json *.tmp *.time *.out


### PR DESCRIPTION
This adjusts the makefile clean targets to use `rm -f`, which will avoid the problem of `make clean` (almost) always returning a non-zero exit code as one or more of the file types it tries to delete don't exist.

Also adds sst checkpoint files `.sstcpt` and `.bin` to gitignore