### PR TITLE
make clean targets less agro

### DIFF
--- a/gameoflife/Makefile
+++ b/gameoflife/Makefile
@@ -16,6 +16,5 @@ install:
 	sst-register gol gol_LIBDIR=$(CURDIR)
 
 clean:
-	rm -rf libgol.so
+	rm -f libgol.so
 	sst-register -u libgol
-	rm -f *.json *.tmp *.time *.out

--- a/phold/Makefile
+++ b/phold/Makefile
@@ -15,11 +15,8 @@ install:
 	sst-register phold phold_LIBDIR=$(CURDIR)
 
 dataclean:
-	 rm -rf *_dir *.out
 	 rm -rf rank_*_thread_*
 
 clean:
-	rm -rf tests/graphs libphold.so
+	rm -f libphold.so
 	sst-register -u phold
-	rm -rf *.json *.tmp *.time *.out
-

--- a/pingpong/Makefile
+++ b/pingpong/Makefile
@@ -17,6 +17,5 @@ install:
 	sst-register pingpong pingpong_LIBDIR=$(CURDIR)
 
 clean:
-	rm -rf tests/graphs libpingpong.so
+	rm -f libpingpong.so
 	sst-register -u pingpong
-	rm -f *.json *.tmp *.time *.out


### PR DESCRIPTION
This adjusts the `clean` targets of our Makefiles to not be so aggressive. Previously the clean target was deleting files that `make` wasn't responsible for, like `*.out`, `*.json`, etc. 

This limits the scope of `clean` to just the removing the shared library and calling the unregister command.