### PR TITLE
add sst v16 to test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
       matrix: &test-matrix
         sst_version:
           - { tag: "15.1.2", image: "ghcr.io/hpc-ai-adv-dev/sst-core:15.1.2" }
+          - { tag: "16.0.0", image: "ghcr.io/hpc-ai-adv-dev/sst-core:16.0.0" }
           - { tag: "master", image: "ghcr.io/hpc-ai-adv-dev/sst-core:master-latest" }
         component: ["gameoflife", "pingpong", "phold"]
         architecture:


### PR DESCRIPTION
Add sst-v16 to the CI test matrix since the official release is out. 

testing of 15.1.2 may be dropped in a future commit to this PR, or in a new PR for just that change.